### PR TITLE
Reorder var init

### DIFF
--- a/includes/modules/bootstrap/product_listing.php
+++ b/includes/modules/bootstrap/product_listing.php
@@ -43,8 +43,9 @@ if ($product_listing_layout_style == 'rows') {
     $list_box_contents[0] = array('params' => 'class="productListing-rowheading"');
 
     $zc_col_count_description = 0;
-    $lc_align = '';
     for ($col = 0, $n = count($column_list); $col < $n; $col++) {
+        $lc_align = '';
+        $lc_text = '';
         switch ($column_list[$col]) {
             case 'PRODUCT_LIST_MODEL':
                 $lc_text = TABLE_HEADING_MODEL;
@@ -126,6 +127,7 @@ if ($num_products_count > 0) {
 
         for ($col = 0, $n = count($column_list); $col < $n; $col++) {
             $lc_align = '';
+            $lc_text = '';
             switch ($column_list[$col]) {
                 case 'PRODUCT_LIST_MODEL':
                     $lc_align = 'center';


### PR DESCRIPTION
This allows commenting-out $lc_text or $lc_align if intended to be skipped, without letting prior values leak in and cause duplicate output