### PR TITLE
Carousels

### DIFF
--- a/includes/modules/bootstrap/bootstrap_additional_images.php
+++ b/includes/modules/bootstrap/bootstrap_additional_images.php
@@ -127,7 +127,7 @@ if ($num_images > 0) {
         $large_link = zen_href_link(FILENAME_POPUP_IMAGE_ADDITIONAL, 'pID=' . $_GET['products_id'] . '&pic=' . $i . '&products_image_large_additional=' . $products_image_large);
 
         $slideNumber = $i + 1; 
-        $thumb = '<a id="carousel-selector-' . $slideNumber . '" data-slide-to="' . $slideNumber . '" data-target="#myCarousel">';
+        $thumb = '<a id="carousel-selector-' . $slideNumber . '" data-slide-to="' . $slideNumber . '" data-target="#productImagesCarousel">';
         $thumb .= $thumb_regular;    
         $thumb .= '</a>';
 

--- a/includes/modules/bootstrap/bootstrap_slide_additional_images.php
+++ b/includes/modules/bootstrap/bootstrap_slide_additional_images.php
@@ -2,7 +2,7 @@
 /**
  * additional_images module
  * 
- * BOOTSTRAP v1.0.BETA
+ * BOOTSTRAP v3.0.0
  *
  * Prepares list of additional product images to be displayed in template
  *
@@ -92,10 +92,10 @@ if ($num_images) {
     // -----
     // This notifier lets any image-handler know the current image being processed, providing the following parameters:
     //
-        // $p1 ... (r/o) ... The current product's name
+    // $p1 ... (r/o) ... The current product's name
     // $p2 ... (r/w) ... The (possibly updated) filename (including path) of the current additional image.
     //
-        $zco_notifier->notify('NOTIFY_MODULES_ADDITIONAL_IMAGES_GET_LARGE', $products_name, $products_image_large);
+    $zco_notifier->notify('NOTIFY_MODULES_ADDITIONAL_IMAGES_GET_LARGE', $products_name, $products_image_large);
 
     $flag_has_large = file_exists($products_image_large);
     $products_image_large = ($flag_has_large ? $products_image_large : $products_image_directory . $file);

--- a/includes/templates/bootstrap/common/tpl_footer.php
+++ b/includes/templates/bootstrap/common/tpl_footer.php
@@ -47,10 +47,10 @@ if (SHOW_FOOTER_IP == '1') {
   if (SHOW_BANNERS_GROUP_SET5 != '' && $banner = zen_banner_exists('dynamic', SHOW_BANNERS_GROUP_SET5)) {
     if ($banner->RecordCount() > 0) {
 $find_banners = zen_build_banners_group(SHOW_BANNERS_GROUP_SET5);
-$show_banner = zen_banner_exists('dynamic', SHOW_BANNERS_GROUP_SET5);
+$banner_group = 5;
 ?>
 
-<div class="bannerFive rounded">
+<div class="zca-banner bannerFive rounded">
 <?php 
 if (ZCA_ACTIVATE_BANNER_FIVE_CAROUSEL == 'true') {
 require($template->get_template_dir('tpl_zca_banner_carousel.php',DIR_WS_TEMPLATE, $current_page_base,'common'). '/tpl_zca_banner_carousel.php'); 

--- a/includes/templates/bootstrap/common/tpl_header.php
+++ b/includes/templates/bootstrap/common/tpl_header.php
@@ -4,13 +4,6 @@
  * 
  * BOOTSTRAP v3.0.0
  *
- * this file can be copied to /templates/your_template_dir/pagename<br />
- * example: to override the privacy page<br />
- * make a directory /templates/my_template/privacy<br />
- * copy /templates/templates_defaults/common/tpl_footer.php to /templates/my_template/privacy/tpl_header.php<br />
- * to override the global settings and turn off the footer un-comment the following line:<br />
- * <br />
- * $flag_disable_header = true;<br />
  *
  * @copyright Copyright 2003-2020 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
@@ -104,7 +97,7 @@ if (!isset($flag_disable_header) || !$flag_disable_header) {
             echo '<div class="col-sm-12">';
             }
             ?>
-        <?php echo '<a href="' . HTTP_SERVER . DIR_WS_CATALOG . '">' . zen_image($template->get_template_dir(HEADER_LOGO_IMAGE, DIR_WS_TEMPLATE, $current_page_base,'images'). '/' . HEADER_LOGO_IMAGE, HEADER_ALT_TEXT, HEADER_LOGO_WIDTH, HEADER_LOGO_HEIGHT) . '</a><br />'; ?>
+        <?php echo '<a href="' . HTTP_SERVER . DIR_WS_CATALOG . '">' . zen_image($template->get_template_dir(HEADER_LOGO_IMAGE, DIR_WS_TEMPLATE, $current_page_base,'images'). '/' . HEADER_LOGO_IMAGE, HEADER_ALT_TEXT, HEADER_LOGO_WIDTH, HEADER_LOGO_HEIGHT) . '</a><br>'; ?>
     </div>
 <?php if (HEADER_SALES_TEXT != '' || (SHOW_BANNERS_GROUP_SET2 != '' && $banner = zen_banner_exists('dynamic', SHOW_BANNERS_GROUP_SET2))) { ?>    
     <div id="taglineWrapper" class="col-sm-12 text-center">
@@ -119,10 +112,10 @@ if (!isset($flag_disable_header) || !$flag_disable_header) {
   if (SHOW_BANNERS_GROUP_SET2 != '' && $banner = zen_banner_exists('dynamic', SHOW_BANNERS_GROUP_SET2)) {
     if ($banner->RecordCount() > 0) {
 $find_banners = zen_build_banners_group(SHOW_BANNERS_GROUP_SET2);
-$show_banner = zen_banner_exists('dynamic', SHOW_BANNERS_GROUP_SET2);
+$banner_group = 2;
 ?>
 
-<div class="bannerTwo rounded">
+<div class="zca-banner bannerTwo rounded">
 <?php 
 if (ZCA_ACTIVATE_BANNER_TWO_CAROUSEL == 'true') {
 require($template->get_template_dir('tpl_zca_banner_carousel.php',DIR_WS_TEMPLATE, $current_page_base,'common'). '/tpl_zca_banner_carousel.php'); 
@@ -149,7 +142,7 @@ echo zen_display_banner('static', $banner);
 <?php require($template->get_template_dir('tpl_modules_categories_tabs.php',DIR_WS_TEMPLATE, $current_page_base,'templates'). '/tpl_modules_categories_tabs.php'); ?>
 <!--eof-optional categories tabs navigation display-->
 
-<br />
+<br>
 
 <!--bof-header ezpage links-->
 <?php if (EZPAGES_STATUS_HEADER == '1' or (EZPAGES_STATUS_HEADER == '2' && zen_is_whitelisted_admin_ip())) { ?>

--- a/includes/templates/bootstrap/common/tpl_main_page.php
+++ b/includes/templates/bootstrap/common/tpl_main_page.php
@@ -96,7 +96,7 @@ $center_column_width = $center_column - $side_columns_total;
   if (SHOW_BANNERS_GROUP_SET1 != '' && $banner = zen_banner_exists('dynamic', SHOW_BANNERS_GROUP_SET1)) {
     if ($banner->RecordCount() > 0) {
 $find_banners = zen_build_banners_group(SHOW_BANNERS_GROUP_SET1);
-$show_banner = zen_banner_exists('dynamic', SHOW_BANNERS_GROUP_SET1);
+$banner_group = 1;
 ?>
 
 <div class="zca-banner bannerOne rounded">
@@ -165,7 +165,7 @@ if (!isset($flag_disable_left) || !$flag_disable_left) {
   if (SHOW_BANNERS_GROUP_SET3 != '' && $banner = zen_banner_exists('dynamic', SHOW_BANNERS_GROUP_SET3)) {
     if ($banner->RecordCount() > 0) {
 $find_banners = zen_build_banners_group(SHOW_BANNERS_GROUP_SET3);
-$show_banner = zen_banner_exists('dynamic', SHOW_BANNERS_GROUP_SET3);
+$banner_group = 3;
 ?>
 
 <div class="zca-banner bannerThree rounded">
@@ -198,7 +198,7 @@ echo zen_display_banner('static', $banner);
   if (SHOW_BANNERS_GROUP_SET4 != '' && $banner = zen_banner_exists('dynamic', SHOW_BANNERS_GROUP_SET4)) {
     if ($banner->RecordCount() > 0) {
 $find_banners = zen_build_banners_group(SHOW_BANNERS_GROUP_SET4);
-$show_banner = zen_banner_exists('dynamic', SHOW_BANNERS_GROUP_SET4);
+$banner_group = 4;
 ?>
 
 <div class="zca-banner bannerFour rounded">
@@ -272,7 +272,7 @@ Parse Time: <?php echo isset($parse_time) ? $parse_time : 'n/a'; ?> - Number of 
   if (SHOW_BANNERS_GROUP_SET6 != '' && $banner = zen_banner_exists('dynamic', SHOW_BANNERS_GROUP_SET6)) {
     if ($banner->RecordCount() > 0) {
 $find_banners = zen_build_banners_group(SHOW_BANNERS_GROUP_SET6);
-$show_banner = zen_banner_exists('dynamic', SHOW_BANNERS_GROUP_SET6);
+$banner_group = 6;
 ?>
 
 <div class="zca-banner bannerSix rounded">

--- a/includes/templates/bootstrap/common/tpl_zca_banner_carousel.php
+++ b/includes/templates/bootstrap/common/tpl_zca_banner_carousel.php
@@ -1,73 +1,59 @@
- <?php
+<?php
 /**
- * 
- * ZCA Homepage Carousel
+ * ZCA Banners Carousel
  * Plugin Template
  * 
- * BOOTSTRAP PRO
+ * BOOTSTRAP v3.0.0
  *
- * @package templateSystem
- * @copyright Copyright 2003-2005 Zen Cart Development Team
- * @copyright Portions Copyright 2003 osCommerce
- * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  */
 
+$content = '';
+$banner_cnt = 0;
 
-    $content = "";
-// select banners_group to be used
-  $new_banner_search = $find_banners;
-
+$new_banner_search = $find_banners;
+$my_banner_filter='';
 // secure pages
-  switch ($request_type) {
-    case ('SSL'):
-      $my_banner_filter=" and banners_on_ssl= " . "1 ";
-      break;
-    case ('NONSSL'):
-      $my_banner_filter='';
-      break;
-  }
-
-  $sql = "select banners_id from " . TABLE_BANNERS . " where status = 1 " . $new_banner_search . $my_banner_filter . " order by banners_sort_order";
-  $banners = $db->Execute($sql);
+if ($request_type === 'SSL') {
+    $my_banner_filter=" AND banners_on_ssl=1";
+}
+$sql = "select banners_id from " . TABLE_BANNERS . " where status = 1 " . $new_banner_search . $my_banner_filter . " order by banners_sort_order";
+$banners = $db->Execute($sql);
 
 // if no active banner in the specified banner group then the box will not show
-  $banner_cnt = 0;
+if ($banners->EOF) {
+  return;
+}
+?>
 
-    $content .= '<div id="carouselExampleIndicators" class="carousel slide" data-ride="carousel">';  
-    $content .= '<ol class="carousel-indicators">';  
-    $content .= '<li data-target="#carouselExampleIndicators" data-slide-to="0" class="active"></li>';  
-    $content .= '<li data-target="#carouselExampleIndicators" data-slide-to="1"></li>';  
-    $content .= '<li data-target="#carouselExampleIndicators" data-slide-to="2"></li>';  
-    $content .= '</ol>';  
-    $content .= '<div class="carousel-inner rounded ">';  
-  
-  while (!$banners->EOF) {
-    $banner_cnt++;
-    $banner = $show_banner;
+<div id="carouselGroup<?php echo (int)$banner_group; ?>" class="carousel slide" data-ride="carousel">
+    <ol class="carousel-indicators">
+       <li data-target="#carouselGroup<?php echo (int)$banner_group; ?>" data-slide-to="0" class="active"></li>
+        <li data-target="#carouselGroup<?php echo (int)$banner_group; ?>" data-slide-to="1"></li>
+        <li data-target="#carouselGroup<?php echo (int)$banner_group; ?>" data-slide-to="2"></li>
+    </ol>
+    <div class="carousel-inner rounded">
+<?php 
+    foreach ($banners as $row) {
+        $banner_cnt++;
     
-    if ($banner_cnt == '1') {
-    $addBannerClass = 'active';    
-    } else {
-    $addBannerClass = '';   
-    }
- 
-    $content .= '<div class="carousel-item '.$addBannerClass.'">';  
-    $content .= zen_display_banner('static', $banners->fields['banners_id']);
-    $content .= '</div>';  
+        $addBannerClass = '';   
+        if ($banner_cnt === 1) {
+            $addBannerClass = 'active';    
+        }
+?>
+        <div class="carousel-item <?php echo $addBannerClass; ?>">
+            <?php echo zen_display_banner('static', $row['banners_id']); ?>
+        </div>
   
-    $banners->MoveNext();
-  }
+<?php } ?>
 
-    $content .= '</div>';
-    $content .= '<a class="carousel-control-prev" href="#carouselExampleIndicators" role="button" data-slide="prev">';
-    $content .= '<span class="carousel-control-prev-icon" aria-hidden="true"></span>';
-    $content .= '<span class="sr-only">Previous</span>';
-    $content .= '</a>';
-    $content .= '<a class="carousel-control-next" href="#carouselExampleIndicators" role="button" data-slide="next">';
-    $content .= '<span class="carousel-control-next-icon" aria-hidden="true"></span>';
-    $content .= '<span class="sr-only">Next</span>';
-    $content .= '</a>';
-    $content .= '</div>';
-
-echo $content;
-?> 
+    </div>
+    <a class="carousel-control-prev" href="#carouselGroup<?php echo (int)$banner_group; ?>" role="button" data-slide="prev">
+      <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+      <span class="sr-only">Previous</span>
+    </a>
+    <a class="carousel-control-next" href="#carouselGroup<?php echo (int)$banner_group; ?>" role="button" data-slide="next">
+      <span class="carousel-control-next-icon" aria-hidden="true"></span>
+      <span class="sr-only">Next</span>
+    </a>
+</div>

--- a/includes/templates/bootstrap/css/stylesheet_bootstrap.carousel.css
+++ b/includes/templates/bootstrap/css/stylesheet_bootstrap.carousel.css
@@ -1,27 +1,23 @@
 /**
  * Image Carousel Stylesheet
  * 
- * BOOTSTRAP v1.0.BETA
+ * BOOTSTRAP v3.0.0
  *
- * @package templateSystem
- * @copyright Copyright 2003-2016 Zen Cart Development Team
- * @copyright Portions Copyright 2003 osCommerce
- * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  */
 
-#myCarousel .carousel-indicators {
+.carousel-indicators {
     position: static;
     left: initial;
     width: initial;
     margin-left: initial;
 }
 
-#myCarousel .carousel-indicators > li {
+.carousel-indicators > li {
     width: initial;
     height: initial;
     text-indent: initial;
 }
 
-#myCarousel .carousel-indicators > li.active img {
+.carousel-indicators > li.active img {
     opacity: 0.7;
 }

--- a/includes/templates/bootstrap/modalboxes/tpl_bootstrap_images.php
+++ b/includes/templates/bootstrap/modalboxes/tpl_bootstrap_images.php
@@ -24,7 +24,7 @@
                     <!-- main slider carousel -->
                     <div class="row">
                         <div class="col-lg-8 offset-lg-2" id="slider">
-                            <div id="myCarousel" class="carousel slide">
+                            <div id="productImagesCarousel" class="carousel slide">
                                 <!-- main slider carousel items -->
                                 <div class="carousel-inner text-center">
 <?php
@@ -53,15 +53,15 @@ if ($flag_show_product_info_additional_images != 0 && $num_images > 0) {
 }
 ?>
                                     <div id="carousel-btn-toolbar" class="btn-toolbar justify-content-between p-3" role="toolbar">
-                                        <a class="carousel-control-prev left pt-3" href="#myCarousel" data-slide="prev"><i class="fa fa-chevron-left"></i></a>
-                                        <a class="carousel-control-next right pt-3" href="#myCarousel" data-slide="next"><i class="fa fa-chevron-right"></i></a>
+                                        <a class="carousel-control-prev left pt-3" href="#productImagesCarousel" data-slide="prev"><i class="fa fa-chevron-left"></i></a>
+                                        <a class="carousel-control-next right pt-3" href="#productImagesCarousel" data-slide="next"><i class="fa fa-chevron-right"></i></a>
                                     </div>
                                 </div>
                                 <!-- main slider carousel nav controls -->
 
                                 <ul class="carousel-indicators list-inline mx-auto justify-content-center py-3">
                                     <li class="list-inline-item active">
-                                        <a id="carousel-selector-0" class="selected" data-slide-to="0" data-target="#myCarousel">
+                                        <a id="carousel-selector-0" class="selected" data-slide-to="0" data-target="#productImagesCarousel">
 <?php
 require DIR_WS_MODULES . zen_get_module_directory('main_product_image.php');
 ?>


### PR DESCRIPTION
- use semantic IDs instead of example code
- reduce banner-related queries
- make each banner-group carousel independent of the others
- fix alignment consistency