### PR TITLE
Set scrollable area on mobile menu

### DIFF
--- a/includes/templates/bootstrap/css/stylesheet.css
+++ b/includes/templates/bootstrap/css/stylesheet.css
@@ -1,7 +1,7 @@
 /**
  * Main Template CSS Stylesheet
  * 
- * BOOTSTRAP v3.0.0
+ * BOOTSTRAP v3.0.1
  *
  */
 

--- a/includes/templates/bootstrap/css/stylesheet.css
+++ b/includes/templates/bootstrap/css/stylesheet.css
@@ -3,10 +3,6 @@
  * 
  * BOOTSTRAP v3.0.0
  *
- * @package templateSystem
- * @copyright Copyright 2003-2016 Zen Cart Development Team
- * @copyright Portions Copyright 2003 osCommerce
- * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  */
 
 /* This is used to re-size images */
@@ -30,6 +26,12 @@ img{max-width:100%;height:auto;border:0;}
 #back-to-top.show {
     opacity: 1;
     z-index: 1;
+}
+
+/* set height of scrollable area in mobile menu */
+div#navbarSupportedContent {
+    max-height:500px;
+    overflow-y:auto;
 }
 
 .zca-banner {


### PR DESCRIPTION
Ref: Issue #13
As reported in [this](https://www.zen-cart.com/showthread.php?223910-ZCA-Bootstrap-4-Template-Support-Thread&p=1375912#post1375912) forum post.

Before: (scrollbar moves but content does not)
<img width="331" alt="Screen Shot 2020-12-21 at 10 57 43 AM" src="https://user-images.githubusercontent.com/404472/102795940-7d783380-437b-11eb-9949-72ffa8d593b8.png">

After: (additional scrollable area for mobile menu content)
<img width="329" alt="Screen Shot 2020-12-21 at 10 56 52 AM" src="https://user-images.githubusercontent.com/404472/102795932-7a7d4300-437b-11eb-9ff0-df20922925f3.png">
