### PR TITLE
Allow product-listing pages to dynamically rearrange based on viewport

### DIFF
--- a/includes/modules/bootstrap/product_listing.php
+++ b/includes/modules/bootstrap/product_listing.php
@@ -2,12 +2,12 @@
 /**
  * product_listing module
  * 
- * BOOTSTRAP v3.0.0
+ * BOOTSTRAP v3.0.1
  *
  * @copyright Copyright 2003-2020 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: DrByte 2020 Sep 20 Modified in v1.5.7a $
+ * @version $Id: DrByte 2020 Dec 26  for v1.5.7 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -17,18 +17,19 @@ $row = 0;
 $col = 0;
 $list_box_contents = [];
 $title = '';
+$show_top_submit_button = false;
+$show_bottom_submit_button = false;
+$error_categories = false;
 
 $show_submit = zen_run_normal();
 
 $columns_per_row = defined('PRODUCT_LISTING_COLUMNS_PER_ROW') ? (int)PRODUCT_LISTING_COLUMNS_PER_ROW : 1;
 if ($columns_per_row < 1) $columns_per_row = 1;
 $product_listing_layout_style = $columns_per_row > 1 ? 'columns' : 'rows';
-$css_grid_suffix = '';
 
 $max_results = (int)MAX_DISPLAY_PRODUCTS_LISTING;
 if ($product_listing_layout_style == 'columns' && $columns_per_row > 1) {
     $max_results = ($columns_per_row * (int)($max_results/$columns_per_row));
-    $css_grid_suffix = '-grid';
 }
 if ($max_results < 1) $max_results = 1;
 
@@ -86,15 +87,19 @@ if ($product_listing_layout_style == 'rows') {
             default:
                 break;
         }
+
+        // Add clickable "sort" links to column headings
         if ($column_list[$col] != 'PRODUCT_LIST_IMAGE') {
             $lc_text = zen_create_sort_heading(isset($_GET['sort']) ? $_GET['sort'] : '', $col+1, $lc_text);
         }
 
+
         $align_class = ($lc_align == '') ? '' : " text-$lc_align";
-        $list_box_contents[0][$col] = array(
+        $list_box_contents[0][$col] = [
+            //'align' => $lc_align, // not used with Bootstrap template: converted to css class below
             'params' => 'class="productListing-heading' . $align_class . '"',
-            'text' => $lc_text 
-        );
+            'text' => $lc_text,
+        ];
     }
 }
 
@@ -106,22 +111,16 @@ $num_products_count = $listing_split->number_of_rows;
 if ($num_products_count > 0) {
     $rows = 0;
     $column = 0;
-    if ($product_listing_layout_style == 'columns') {
-        if ($num_products_count < $columns_per_row || $columns_per_row == 0 ) {
-            $col_width = floor(100/$num_products_count) - 0.5;
-        } else {
-            $col_width = floor(100/$columns_per_row) - 0.5;
-        }
-    }
     $listing = $db->Execute($listing_split->sql_query);
     $extra_row = 0;
-    while (!$listing->EOF) {
+    foreach ($listing as $record) {
         if ($product_listing_layout_style == 'rows') {
             $rows++;
         }
-        $product_contents = array();
 
-        $linkCpath = $listing->fields['master_categories_id'];
+        $product_contents = [];
+
+        $linkCpath = $record['master_categories_id'];
         if (!empty($_GET['cPath'])) $linkCpath = $_GET['cPath'];
         if (!empty($_GET['manufacturers_id']) && !empty($_GET['filter_id'])) $linkCpath = $_GET['filter_id'];
 
@@ -131,99 +130,99 @@ if ($num_products_count > 0) {
             switch ($column_list[$col]) {
                 case 'PRODUCT_LIST_MODEL':
                     $lc_align = 'center';
-                    $lc_text = $listing->fields['products_model'];
+                    $lc_text = $record['products_model'];
                     break;
                 case 'PRODUCT_LIST_NAME':
                     $lc_align = 'center';
                     $lc_text = '<h3 class="itemTitle">
-                        <a href="' . zen_href_link(zen_get_info_page($listing->fields['products_id']), 'cPath=' . zen_get_generated_category_path_rev($linkCpath) . '&products_id=' . $listing->fields['products_id']) . '">' . $listing->fields['products_name'] . '</a>
+                        <a href="' . zen_href_link(zen_get_info_page($record['products_id']), 'cPath=' . zen_get_generated_category_path_rev($linkCpath) . '&products_id=' . $record['products_id']) . '">' . $record['products_name'] . '</a>
                         </h3>';
                         if ((int)PRODUCT_LIST_DESCRIPTION > 0) {
                             $lc_text .= '
-                            <div class="listingDescription">' . zen_trunc_string(zen_clean_html(stripslashes(zen_get_products_description($listing->fields['products_id'], $_SESSION['languages_id']))), PRODUCT_LIST_DESCRIPTION) . '</div>';
+                            <div class="listingDescription">' . zen_trunc_string(zen_clean_html(stripslashes(zen_get_products_description($record['products_id'], $_SESSION['languages_id']))), PRODUCT_LIST_DESCRIPTION) . '</div>';
                         }
                     break;
                 case 'PRODUCT_LIST_MANUFACTURER':
                     $lc_align = 'center';
-                    $lc_text = '<a href="' . zen_href_link(FILENAME_DEFAULT, 'manufacturers_id=' . $listing->fields['manufacturers_id']) . '">' . $listing->fields['manufacturers_name'] . '</a>';
+                    $lc_text = '<a href="' . zen_href_link(FILENAME_DEFAULT, 'manufacturers_id=' . $record['manufacturers_id']) . '">' . $record['manufacturers_name'] . '</a>';
                     break;
                 case 'PRODUCT_LIST_PRICE':
-                    $lc_price = zen_get_products_display_price($listing->fields['products_id']) . '<br>';
+                    $lc_price = zen_get_products_display_price($record['products_id']) . '<br>';
                     $lc_align = 'center';
                     $lc_text =  $lc_price;
 
                     // more info in place of buy now
                     $lc_button = '';
-                    if (zen_requires_attribute_selection($listing->fields['products_id']) or PRODUCT_LIST_PRICE_BUY_NOW == '0') {
-                        $lc_button = '<a href="' . zen_href_link(zen_get_info_page($listing->fields['products_id']), 'cPath=' . zen_get_generated_category_path_rev($linkCpath) . '&products_id=' . $listing->fields['products_id']) . '">' . MORE_INFO_TEXT . '</a>';
+                    if (zen_requires_attribute_selection($record['products_id']) || PRODUCT_LIST_PRICE_BUY_NOW == '0') {
+                        $lc_button = '<a href="' . zen_href_link(zen_get_info_page($record['products_id']), 'cPath=' . zen_get_generated_category_path_rev($linkCpath) . '&products_id=' . $record['products_id']) . '">' . MORE_INFO_TEXT . '</a>';
                     } else {
                         if (PRODUCT_LISTING_MULTIPLE_ADD_TO_CART != 0) {
                             if (
                                 // not a hide qty box product
-                                $listing->fields['products_qty_box_status'] != 0 &&
+                                $record['products_qty_box_status'] != 0 &&
                                 // product type can be added to cart
-                                zen_get_products_allow_add_to_cart($listing->fields['products_id']) != 'N'
+                                zen_get_products_allow_add_to_cart($record['products_id']) != 'N'
                                 &&
                                 // product is not call for price
-                                $listing->fields['product_is_call'] == 0
+                                $record['product_is_call'] == 0
                                 &&
                                 // product is in stock or customers may add it to cart anyway
-                                ($listing->fields['products_quantity'] > 0 || SHOW_PRODUCTS_SOLD_OUT_IMAGE == 0) ) 
+                                ($record['products_quantity'] > 0 || SHOW_PRODUCTS_SOLD_OUT_IMAGE == 0) ) 
                             {
                                 $how_many++;
                             }
                             // hide quantity box
-                            if ($listing->fields['products_qty_box_status'] == 0) {
-                                $lc_button = '<a href="' . zen_href_link($_GET['main_page'], zen_get_all_get_params(array('action')) . 'action=buy_now&products_id=' . $listing->fields['products_id']) . '">' . zen_image_button(BUTTON_IMAGE_BUY_NOW, BUTTON_BUY_NOW_ALT, 'class="listingBuyNowButton"') . '</a>';
+                            if ($record['products_qty_box_status'] == 0) {
+                                $lc_button = '<a href="' . zen_href_link($_GET['main_page'], zen_get_all_get_params(array('action')) . 'action=buy_now&products_id=' . $record['products_id']) . '">' . zen_image_button(BUTTON_IMAGE_BUY_NOW, BUTTON_BUY_NOW_ALT, 'class="listingBuyNowButton"') . '</a>';
                             } else {
-                                $lc_button = '<div class="input-group mb-3"><div class="input-group-prepend"><span class="input-group-text">' . TEXT_PRODUCT_LISTING_MULTIPLE_ADD_TO_CART . '</span></div>' . '<input class="form-control"  type="text" name="products_id[' . $listing->fields['products_id'] . ']" value="0" size="4" aria-label="' . ARIA_QTY_ADD_TO_CART . '"></div>';
+                                $lc_button = '<div class="input-group mb-3"><div class="input-group-prepend">';
+                                $lc_button .= '<span class="input-group-text">' . TEXT_PRODUCT_LISTING_MULTIPLE_ADD_TO_CART . '</span></div>';
+                                $lc_button .= '<input class="form-control"  type="text" name="products_id[' . $record['products_id'] . ']" value="0" size="4" aria-label="' . ARIA_QTY_ADD_TO_CART . '">';
+                                $lc_button .= '</div>';
                             }
                         } else {
                         // qty box with add to cart button
-                            if (PRODUCT_LIST_PRICE_BUY_NOW == '2' && $listing->fields['products_qty_box_status'] != 0) {
-                                $lc_button= zen_draw_form('cart_quantity', zen_href_link($_GET['main_page'], zen_get_all_get_params(array('action')) . 'action=add_product&products_id=' . $listing->fields['products_id']), 'post', 'enctype="multipart/form-data"') . '<input type="text" name="cart_quantity" value="' . (zen_get_buy_now_qty($listing->fields['products_id'])) . '" maxlength="6" size="4" aria-label="' . ARIA_QTY_ADD_TO_CART . '"><br>' . zen_draw_hidden_field('products_id', $listing->fields['products_id']) . zen_image_submit(BUTTON_IMAGE_IN_CART, BUTTON_IN_CART_ALT) . '</form>';
+                            if (PRODUCT_LIST_PRICE_BUY_NOW == '2' && $record['products_qty_box_status'] != 0) {
+                                $lc_button= zen_draw_form('cart_quantity', zen_href_link($_GET['main_page'], zen_get_all_get_params(array('action')) . 'action=add_product&products_id=' . $record['products_id']), 'post', 'enctype="multipart/form-data"') . '<input type="text" name="cart_quantity" value="' . (zen_get_buy_now_qty($record['products_id'])) . '" maxlength="6" size="4" aria-label="' . ARIA_QTY_ADD_TO_CART . '"><br>' . zen_draw_hidden_field('products_id', $record['products_id']) . zen_image_submit(BUTTON_IMAGE_IN_CART, BUTTON_IN_CART_ALT) . '</form>';
                             } else {
-                                $lc_button = '<a href="' . zen_href_link($_GET['main_page'], zen_get_all_get_params(array('action')) . 'action=buy_now&products_id=' . $listing->fields['products_id']) . '">' . zen_image_button(BUTTON_IMAGE_BUY_NOW, BUTTON_BUY_NOW_ALT, 'class="listingBuyNowButton"') . '</a>';
+                                $lc_button = '<a href="' . zen_href_link($_GET['main_page'], zen_get_all_get_params(array('action')) . 'action=buy_now&products_id=' . $record['products_id']) . '">' . zen_image_button(BUTTON_IMAGE_BUY_NOW, BUTTON_BUY_NOW_ALT, 'class="listingBuyNowButton"') . '</a>';
                             }
                         }
                     }
                     
-                    $zco_notifier->notify('NOTIFY_MODULES_PRODUCT_LISTING_PRODUCTS_BUTTON', array(), $listing->fields, $lc_button);
+                    $zco_notifier->notify('NOTIFY_MODULES_PRODUCT_LISTING_PRODUCTS_BUTTON', array(), $record, $lc_button);
                     
                     $the_button = $lc_button;
-                    $products_link = '<a href="' . zen_href_link(zen_get_info_page($listing->fields['products_id']), 'cPath=' . zen_get_generated_category_path_rev($linkCpath) . '&products_id=' . $listing->fields['products_id']) . '">' . MORE_INFO_TEXT . '</a>';
-                    $lc_text .= '<br>' . zen_get_buy_now_button($listing->fields['products_id'], $the_button, $products_link) . '<br>' . zen_get_products_quantity_min_units_display($listing->fields['products_id']);
-                    $lc_text .= '<br>' . (zen_get_show_product_switch($listing->fields['products_id'], 'ALWAYS_FREE_SHIPPING_IMAGE_SWITCH') ? (zen_get_product_is_always_free_shipping($listing->fields['products_id']) ? TEXT_PRODUCT_FREE_SHIPPING_ICON . '<br>' : '') : '');
+                    $products_link = '<a href="' . zen_href_link(zen_get_info_page($record['products_id']), 'cPath=' . zen_get_generated_category_path_rev($linkCpath) . '&products_id=' . $record['products_id']) . '">' . MORE_INFO_TEXT . '</a>';
+                    $lc_text .= '<br>' . zen_get_buy_now_button($record['products_id'], $the_button, $products_link) . '<br>' . zen_get_products_quantity_min_units_display($record['products_id']);
+                    $lc_text .= '<br>' . (zen_get_show_product_switch($record['products_id'], 'ALWAYS_FREE_SHIPPING_IMAGE_SWITCH') ? (zen_get_product_is_always_free_shipping($record['products_id']) ? TEXT_PRODUCT_FREE_SHIPPING_ICON . '<br>' : '') : '');
 
                     break;
                 case 'PRODUCT_LIST_QUANTITY':
                     $lc_align = 'center';
-                    $lc_text = $listing->fields['products_quantity'];
+                    $lc_text = $record['products_quantity'];
                     break;
                 case 'PRODUCT_LIST_WEIGHT':
                     $lc_align = 'center';
-                    $lc_text = $listing->fields['products_weight'];
+                    $lc_text = $record['products_weight'];
                     break;
                 case 'PRODUCT_LIST_IMAGE':
                     $lc_align = 'center';
-                    if ($listing->fields['products_image'] == '' and PRODUCTS_IMAGE_NO_IMAGE_STATUS == 0) {
-                        $lc_text = '';
-                    } else {
-                        $lc_text = '<a href="' . zen_href_link(zen_get_info_page($listing->fields['products_id']), 'cPath=' . zen_get_generated_category_path_rev($linkCpath) . '&products_id=' . $listing->fields['products_id']) . '">' . zen_image(DIR_WS_IMAGES . $listing->fields['products_image'], $listing->fields['products_name'], IMAGE_PRODUCT_LISTING_WIDTH, IMAGE_PRODUCT_LISTING_HEIGHT, 'class="listingProductImage"') . '</a>';
+                    if (!empty($record['products_image']) || PRODUCTS_IMAGE_NO_IMAGE_STATUS > 0) {
+                        $lc_text = '<a href="' . zen_href_link(zen_get_info_page($record['products_id']), 'cPath=' . zen_get_generated_category_path_rev($linkCpath) . '&products_id=' . $record['products_id']) . '">' . zen_image(DIR_WS_IMAGES . $record['products_image'], $record['products_name'], IMAGE_PRODUCT_LISTING_WIDTH, IMAGE_PRODUCT_LISTING_HEIGHT, 'class="listingProductImage"') . '</a>';
                     }
-                    break;
-                default:
                     break;
             }
 
             $product_contents[] = $lc_text; // (used in column mode)
 
             if ($product_listing_layout_style == 'rows') {
-                $align_class = ($lc_align == '') ? '' : " text-$lc_align";
-                $list_box_contents[$rows][$col] = array(
+                $align_class = empty($lc_align) ? '' : " text-$lc_align";
+                $list_box_contents[$rows][$col] = [
+                    //'align' => $lc_align, // not used with Bootstrap template: converted to css class below
                     'params' => 'class="productListing-data' . $align_class . '"',
-                    'text'  => $lc_text
-                );
+                    'text'  => $lc_text,
+                ];
 //        // add description and match alternating colors
 //        if (PRODUCT_LIST_DESCRIPTION > 0) {
 //          $rows++;
@@ -235,47 +234,41 @@ if ($num_products_count > 0) {
 //            $extra_row=1;
 //          }
 //          $list_box_contents[$rows][] = array('params' => 'class="' . $list_box_description . '" colspan="' . $zc_col_count_description . '"',
-//                                              'text' => zen_trunc_string(zen_clean_html(stripslashes(zen_get_products_description($listing->fields['products_id'], $_SESSION['languages_id']))), PRODUCT_LIST_DESCRIPTION));
+//                                              'text' => zen_trunc_string(zen_clean_html(stripslashes(zen_get_products_description($record['products_id'], $_SESSION['languages_id']))), PRODUCT_LIST_DESCRIPTION));
 //        }
             }
         }
 
         if ($product_listing_layout_style == 'columns') {
             $lc_text = implode('<br>', $product_contents);
-            $list_box_contents[$rows][$column] = array(
+            $list_box_contents[$rows][$column] = [
                 'params' => 'class="card mb-3 p-3 centerBoxContentsListing text-center"',
-                'text'  => $lc_text
-            );
+                'text'  => $lc_text,
+            ];
             $column ++;
             if ($column >= $columns_per_row) {
                 $column = 0;
                 $rows++;
             }
         }
-
-        $listing->MoveNext();
     }
-    $error_categories = false;
 } else {
 
-    $list_box_contents = array();
+    $list_box_contents = [];
 
-    $list_box_contents[0] = array('params' => 'class="productListing-odd"');
-    $list_box_contents[0][] = array('params' => 'class="productListing-data"',
-                                                'text' => TEXT_NO_PRODUCTS);
-
+    //$list_box_contents[0] = ['params' => 'class="productListing-odd"'];
+    $list_box_contents[0][] = [
+        'params' => 'class="productListing-data"',
+        'text' => TEXT_NO_PRODUCTS,
+    ];
     $error_categories = true;
 }
 
 if (($how_many > 0 && $show_submit == true && $num_products_count > 0) && (PRODUCT_LISTING_MULTIPLE_ADD_TO_CART == 1 ||  PRODUCT_LISTING_MULTIPLE_ADD_TO_CART == 3) ) {
     $show_top_submit_button = true;
-} else {
-    $show_top_submit_button = false;
 }
 if (($how_many > 0 && $show_submit == true && $num_products_count > 0) && (PRODUCT_LISTING_MULTIPLE_ADD_TO_CART >= 2) ) {
     $show_bottom_submit_button = true;
-} else {
-    $show_bottom_submit_button = false;
 }
 
 $zco_notifier->notify('NOTIFY_PRODUCT_LISTING_END', $current_page_base, $list_box_contents, $listing_split, $show_top_submit_button, $show_bottom_submit_button, $show_submit, $how_many);

--- a/includes/modules/bootstrap/product_listing.php
+++ b/includes/modules/bootstrap/product_listing.php
@@ -7,7 +7,7 @@
  * @copyright Copyright 2003-2020 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: DrByte 2020 Dec 26  for v1.5.7 $
+ * @version $Id: DrByte 2020 Dec 27  for v1.5.7 $
  */
 if (!defined('IS_ADMIN_FLAG')) {
   die('Illegal Access');
@@ -130,13 +130,15 @@ if ($num_products_count > 0) {
             switch ($column_list[$col]) {
                 case 'PRODUCT_LIST_MODEL':
                     $lc_align = 'center';
-                    $lc_text = $record['products_model'];
+                    $lc_text = '';
+                    //if ($product_listing_layout_style == 'columns') $lc_text .= '<label>' . TABLE_HEADING_MODEL . '</label>';
+                    $lc_text .= $record['products_model'];
                     break;
                 case 'PRODUCT_LIST_NAME':
-                    $lc_align = 'center';
-                    $lc_text = '<h3 class="itemTitle">
+                    if ($product_listing_layout_style == 'columns') $lc_align = 'center';
+                    $lc_text = '<h5 class="itemTitle">
                         <a href="' . zen_href_link(zen_get_info_page($record['products_id']), 'cPath=' . zen_get_generated_category_path_rev($linkCpath) . '&products_id=' . $record['products_id']) . '">' . $record['products_name'] . '</a>
-                        </h3>';
+                        </h5>';
                         if ((int)PRODUCT_LIST_DESCRIPTION > 0) {
                             $lc_text .= '
                             <div class="listingDescription">' . zen_trunc_string(zen_clean_html(stripslashes(zen_get_products_description($record['products_id'], $_SESSION['languages_id']))), PRODUCT_LIST_DESCRIPTION) . '</div>';
@@ -144,12 +146,16 @@ if ($num_products_count > 0) {
                     break;
                 case 'PRODUCT_LIST_MANUFACTURER':
                     $lc_align = 'center';
-                    $lc_text = '<a href="' . zen_href_link(FILENAME_DEFAULT, 'manufacturers_id=' . $record['manufacturers_id']) . '">' . $record['manufacturers_name'] . '</a>';
+                    $lc_text = '';
+                    //if ($product_listing_layout_style == 'columns') $lc_text .= '<label>' . TABLE_HEADING_MANUFACTURER . '</label>';
+                    $lc_text .= '<a href="' . zen_href_link(FILENAME_DEFAULT, 'manufacturers_id=' . $record['manufacturers_id']) . '">' . $record['manufacturers_name'] . '</a>';
                     break;
                 case 'PRODUCT_LIST_PRICE':
                     $lc_price = zen_get_products_display_price($record['products_id']) . '<br>';
                     $lc_align = 'center';
-                    $lc_text =  $lc_price;
+                    $lc_text = '';
+                    // if ($product_listing_layout_style == 'columns') $lc_text .= '<label>' . TABLE_HEADING_PRICE . '</label>';
+                    $lc_text .=  $lc_price;
 
                     // more info in place of buy now
                     $lc_button = '';
@@ -167,8 +173,9 @@ if ($num_products_count > 0) {
                                 $record['product_is_call'] == 0
                                 &&
                                 // product is in stock or customers may add it to cart anyway
-                                ($record['products_quantity'] > 0 || SHOW_PRODUCTS_SOLD_OUT_IMAGE == 0) ) 
-                            {
+                                ($record['products_quantity'] > 0 || SHOW_PRODUCTS_SOLD_OUT_IMAGE == 0) 
+
+                            ) {
                                 $how_many++;
                             }
                             // hide quantity box
@@ -200,11 +207,15 @@ if ($num_products_count > 0) {
                     break;
                 case 'PRODUCT_LIST_QUANTITY':
                     $lc_align = 'center';
-                    $lc_text = $record['products_quantity'];
+                    $lc_text = '';
+                    //if ($product_listing_layout_style == 'columns') $lc_text .= '<label>' . TABLE_HEADING_QUANTITY . '</label>';
+                    $lc_text .= $record['products_quantity'];
                     break;
                 case 'PRODUCT_LIST_WEIGHT':
                     $lc_align = 'center';
-                    $lc_text = $record['products_weight'];
+                    $lc_text = '';
+                    //if ($product_listing_layout_style == 'columns') $lc_text .= '<label>' . TABLE_HEADING_WEIGHT . '</label>';
+                    $lc_text .= $record['products_weight'];
                     break;
                 case 'PRODUCT_LIST_IMAGE':
                     $lc_align = 'center';
@@ -218,7 +229,7 @@ if ($num_products_count > 0) {
 
             if ($product_listing_layout_style == 'rows') {
                 $align_class = empty($lc_align) ? '' : " text-$lc_align";
-                $list_box_contents[$rows][$col] = [
+                $list_box_contents[$rows][] = [
                     //'align' => $lc_align, // not used with Bootstrap template: converted to css class below
                     'params' => 'class="productListing-data' . $align_class . '"',
                     'text'  => $lc_text,
@@ -241,7 +252,7 @@ if ($num_products_count > 0) {
 
         if ($product_listing_layout_style == 'columns') {
             $lc_text = implode('<br>', $product_contents);
-            $list_box_contents[$rows][$column] = [
+            $list_box_contents[$rows][] = [
                 'params' => 'class="card mb-3 p-3 centerBoxContentsListing text-center"',
                 'text'  => $lc_text,
             ];

--- a/includes/modules/bootstrap/product_listing.php
+++ b/includes/modules/bootstrap/product_listing.php
@@ -209,7 +209,7 @@ if ($num_products_count > 0) {
                 case 'PRODUCT_LIST_IMAGE':
                     $lc_align = 'center';
                     if (!empty($record['products_image']) || PRODUCTS_IMAGE_NO_IMAGE_STATUS > 0) {
-                        $lc_text = '<a href="' . zen_href_link(zen_get_info_page($record['products_id']), 'cPath=' . zen_get_generated_category_path_rev($linkCpath) . '&products_id=' . $record['products_id']) . '">' . zen_image(DIR_WS_IMAGES . $record['products_image'], $record['products_name'], IMAGE_PRODUCT_LISTING_WIDTH, IMAGE_PRODUCT_LISTING_HEIGHT, 'class="listingProductImage"') . '</a>';
+                        $lc_text = '<a href="' . zen_href_link(zen_get_info_page($record['products_id']), 'cPath=' . zen_get_generated_category_path_rev($linkCpath) . '&products_id=' . $record['products_id']) . '">' . zen_image(DIR_WS_IMAGES . $record['products_image'], $record['products_name'], IMAGE_PRODUCT_LISTING_WIDTH, IMAGE_PRODUCT_LISTING_HEIGHT, 'class="img-fluid listingProductImage"') . '</a>';
                     }
                     break;
             }

--- a/includes/templates/bootstrap/common/tpl_columnar_display.php
+++ b/includes/templates/bootstrap/common/tpl_columnar_display.php
@@ -2,58 +2,65 @@
 /**
  * Common Template - tpl_columnar_display.php
  *
- * BOOTSTRAP v3.0.0
+ * BOOTSTRAP v3.0.1
  *
- * This file is used for generating tabular output where needed, based on the supplied array of table-cell contents.
+ * This file is used for generating columnar output where needed, based on the supplied array of table-cell contents.
  *
  * @copyright Copyright 2003-2020 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: lat9 2020 Jul 27 Modified in v1.5.7a $
+ * @version $Id: DrByte 2020 Dec 27  For v1.5.7 $
  */
 
 $zco_notifier->notify('NOTIFY_TPL_COLUMNAR_DISPLAY_START', $current_page_base, $list_box_contents, $title);
-
 ?>
 
 <div class="card mb-3">
-  
-<?php
-  if ($title) {
-  ?>
 
+<?php if ($title) { ?>
 <?php echo $title; ?>
+<?php } ?>
 
-<?php
- }
- ?>
 <div class="card-body text-center">
 <?php
 if (is_array($list_box_contents)) {
- for($row=0, $n=sizeof($list_box_contents); $row<$n; $row++) {
-    $params = "";
-    //if (isset($list_box_contents[$row]['params'])) $params .= ' ' . $list_box_contents[$row]['params'];
+    foreach ($list_box_contents as $row => $cols) {
+
+        $r_params = 'class="card-deck text-center"';
+        if (isset($list_box_contents[$row]['params'])) {
+            $r_params = $list_box_contents[$row]['params'];
+        }
 ?>
 
-<div class="card-deck text-center">
+<div <?php echo $r_params; ?>>
 <?php
-    for($col=0, $j=sizeof($list_box_contents[$row]); $col<$j; $col++) {
-      $r_params = "";
-      if (isset($list_box_contents[$row][$col]['params'])) $r_params .= ' ' . (string)$list_box_contents[$row][$col]['params'];
-     if (isset($list_box_contents[$row][$col]['text'])) {
-?>
-    <?php echo '<div' . $r_params . '>' . $list_box_contents[$row][$col]['text'] .  '</div>'; ?>
-<?php
-      }
+    foreach ($cols as $col) {
+        if ($cols === 'params') {
+            continue; // a $cols index named 'params' is only display-instructions ($r_params above) for the row, no data, so skip this iteration
+        }
+
+        if (!empty($col['wrap_with_classes'])) { 
+            echo '<div class="' . $col['wrap_with_classes'] . '">';
+        }
+
+        $c_params = "";
+        if (isset($col['params'])) $c_params .= ' ' . (string)$col['params'];
+        if (isset($col['text'])) {
+            echo '<div' . $c_params . '>' . $col['text'] .  '</div>';
+        }
+
+        if (!empty($col['wrap_with_classes'])) { 
+            echo '</div>';
+        }
+        echo PHP_EOL;
     }
 ?>
 </div>
 
-
 <?php
   }
 }
- ?>
+?>
 </div>
 </div>
 

--- a/includes/templates/bootstrap/templates/tpl_modules_product_listing.php
+++ b/includes/templates/bootstrap/templates/tpl_modules_product_listing.php
@@ -44,7 +44,7 @@
 /**
  * load the list_box_content template to display the products
  */
-if ($product_listing_layout_style == 'columns') {
+if (in_array($product_listing_layout_style, ['columns', 'fluid'])) {
   require($template->get_template_dir('tpl_columnar_display.php',DIR_WS_TEMPLATE, $current_page_base,'common'). '/tpl_columnar_display.php');
 } else {
   require($template->get_template_dir('tpl_tabular_display.php',DIR_WS_TEMPLATE, $current_page_base,'common'). '/tpl_tabular_display.php');


### PR DESCRIPTION
Using `grid-cards` allows the viewport and orientation to determine how many card cells to show per row.

<img width="268" alt="Screen Shot 2020-12-27 at 3 54 11 PM" src="https://user-images.githubusercontent.com/404472/103179620-e53aec80-485b-11eb-87bc-c93f09f1c097.png"><img width="481" alt="Screen Shot 2020-12-27 at 3 54 22 PM" src="https://user-images.githubusercontent.com/404472/103179624-eb30cd80-485b-11eb-9152-442e20d7f768.png">

<img width="647" alt="Screen Shot 2020-12-27 at 3 54 36 PM" src="https://user-images.githubusercontent.com/404472/103179625-ef5ceb00-485b-11eb-8c96-87d08888e127.png">

<img width="884" alt="Screen Shot 2020-12-27 at 3 54 47 PM" src="https://user-images.githubusercontent.com/404472/103179626-f2f07200-485b-11eb-8c56-648d372cf367.png">
