### PR TITLE
Add a Download SQL button to ZCA Bootrstrap Colors

### DIFF
--- a/YOUR_ADMIN/includes/languages/english/zca_bootstrap_colors.php
+++ b/YOUR_ADMIN/includes/languages/english/zca_bootstrap_colors.php
@@ -18,10 +18,6 @@ define('TABLE_HEADING_CONFIGURATION_TITLE', 'Title');
 define('TABLE_HEADING_CONFIGURATION_VALUE', 'Value');
 define('TABLE_HEADING_ACTION', 'Action');
 
-// BOF SQL file
-define('BUTTON_DOWNLOAD_SQL', 'Download SQL');
-// EOF SQL file
-
 // BOF CSV file
 define('BUTTON_DOWNLOAD_CSV', 'Download CSV');
 define('BUTTON_UPLOAD_CSV', 'Upload CSV');

--- a/YOUR_ADMIN/includes/languages/english/zca_bootstrap_colors.php
+++ b/YOUR_ADMIN/includes/languages/english/zca_bootstrap_colors.php
@@ -18,6 +18,10 @@ define('TABLE_HEADING_CONFIGURATION_TITLE', 'Title');
 define('TABLE_HEADING_CONFIGURATION_VALUE', 'Value');
 define('TABLE_HEADING_ACTION', 'Action');
 
+// BOF SQL file
+define('BUTTON_DOWNLOAD_SQL', 'Download SQL');
+// EOF SQL file
+
 // BOF CSV file
 define('BUTTON_DOWNLOAD_CSV', 'Download CSV');
 define('BUTTON_UPLOAD_CSV', 'Upload CSV');
@@ -30,8 +34,10 @@ define('CSV_HEADER_TITLE', 'Title');
 define('UPLOAD_FILE_PROCESSED_ALL_OK', "File Processed; all %s updates successful."); 
 define('UPLOAD_FILE_PROCESSED_SOME_OK', "File Processed; %s out of %s updates successful."); 
 
-define('UPLOAD_SUCCESS', 'Success: '); 
-define('UPLOAD_WARNING', 'Warning: '); 
-define('UPLOAD_FAILED', 'Failed: '); 
-define('NO_CSV_FILE', 'CSV File not specified or empty.'); 
+define('UPLOAD_SUCCESS', 'Success: ');
+define('UPLOAD_WARNING', 'Warning: ');
+define('UPLOAD_FAILED', 'Failed: ');
+define('MISSING_CONFIGURATION', 'Missing configuration');
+define('NO_CSV_FILE', 'CSV File not specified or empty.');
+define('CSV_FILE_MALFORMED', 'CSV file malformed.');
 // EOF CSV file

--- a/YOUR_ADMIN/includes/languages/english/zca_bootstrap_colors.php
+++ b/YOUR_ADMIN/includes/languages/english/zca_bootstrap_colors.php
@@ -18,6 +18,24 @@ define('TABLE_HEADING_CONFIGURATION_TITLE', 'Title');
 define('TABLE_HEADING_CONFIGURATION_VALUE', 'Value');
 define('TABLE_HEADING_ACTION', 'Action');
 
-// BOF download SQL file
+// BOF SQL file
 define('BUTTON_DOWNLOAD_SQL', 'Download SQL');
-// EOF download SQL file
+// EOF SQL file
+
+// BOF CSV file
+define('BUTTON_DOWNLOAD_CSV', 'Download CSV');
+define('BUTTON_UPLOAD_CSV', 'Upload CSV');
+define('TEXT_QUERY_FILENAME','Upload file:');
+
+define('CSV_HEADER_KEY', 'Key');
+define('CSV_HEADER_VALUE', 'Value');
+define('CSV_HEADER_TITLE', 'Title');
+
+define('UPLOAD_FILE_PROCESSED_ALL_OK', "File Processed; all %s updates successful."); 
+define('UPLOAD_FILE_PROCESSED_SOME_OK', "File Processed; %s out of %s updates successful."); 
+
+define('UPLOAD_SUCCESS', 'Success: '); 
+define('UPLOAD_WARNING', 'Warning: '); 
+define('UPLOAD_FAILED', 'Failed: '); 
+define('NO_CSV_FILE', 'CSV File not specified or empty.'); 
+// EOF CSV file

--- a/YOUR_ADMIN/includes/languages/english/zca_bootstrap_colors.php
+++ b/YOUR_ADMIN/includes/languages/english/zca_bootstrap_colors.php
@@ -37,7 +37,7 @@ define('UPLOAD_FILE_PROCESSED_SOME_OK', "File Processed; %s out of %s updates su
 define('UPLOAD_SUCCESS', 'Success: ');
 define('UPLOAD_WARNING', 'Warning: ');
 define('UPLOAD_FAILED', 'Failed: ');
-define('MISSING_CONFIGURATION', 'Missing configuration');
+define('MISSING_CONFIGURATION', 'ZCA Bootstrap Colors configuration not found.');
 define('NO_CSV_FILE', 'CSV File not specified or empty.');
 define('CSV_FILE_MALFORMED', 'CSV file malformed.');
 // EOF CSV file

--- a/YOUR_ADMIN/includes/languages/english/zca_bootstrap_colors.php
+++ b/YOUR_ADMIN/includes/languages/english/zca_bootstrap_colors.php
@@ -17,3 +17,7 @@ define('TEXT_INFO_LAST_MODIFIED', 'Last Modified:');
 define('TABLE_HEADING_CONFIGURATION_TITLE', 'Title');
 define('TABLE_HEADING_CONFIGURATION_VALUE', 'Value');
 define('TABLE_HEADING_ACTION', 'Action');
+
+// BOF download SQL file
+define('BUTTON_DOWNLOAD_SQL', 'Download SQL');
+// EOF download SQL file

--- a/YOUR_ADMIN/zca_bootstrap_colors.php
+++ b/YOUR_ADMIN/zca_bootstrap_colors.php
@@ -8,23 +8,18 @@
  */
 require('includes/application_top.php');
 
-$action = (isset($_GET['action']) ? $_GET['action'] : '');
-
 $sqlGroup = "SELECT configuration_group_id
              FROM " . TABLE_CONFIGURATION_GROUP . "
              WHERE configuration_group_title = 'ZCA Bootstrap Colors'";
 $groupID = $db->Execute($sqlGroup);
 // Without a valid config group present, it means the ZCA Bootstrap module isn't installed/configured yet/anymore.
-if (empty($groupID->fields['configuration_group_id'])) {
-  //$messageStack->add_session(MISSING_CONFIGURATION, 'error');
-  //zen_redirect(zen_href_link(FILENAME_DEFAULT));
-
-  $messageStack->add(MISSING_CONFIGURATION, 'error');
-  $gID = 0;                             // unused configuration group
-  $action = '';                         // block any pending action
-} else {
-  $gID = $groupID->fields['configuration_group_id'];
+if ($groupID->EOF) {
+  $messageStack->add_session(MISSING_CONFIGURATION, 'error');
+  zen_redirect(zen_href_link(FILENAME_DEFAULT));
 }
+$gID = $groupID->fields['configuration_group_id'];
+
+$action = (isset($_GET['action']) ? $_GET['action'] : '');
 
 if (!empty($action)) {
   switch ($action) {

--- a/YOUR_ADMIN/zca_bootstrap_colors.php
+++ b/YOUR_ADMIN/zca_bootstrap_colors.php
@@ -227,7 +227,7 @@ $cfg_group = $db->Execute("SELECT configuration_group_title
             <?php echo '</form>'; ?>
           </div>
           <div class="row text-right">
-            <a class="btn btn-primary" role="button" href="<?= zen_href_link(FILENAME_ZCA_BOOTSTRAP_COLORS, 'downloadcsv=1', 'SSL') ?>"><?= BUTTON_DOWNLOAD_CSV; ?></a>
+            <a class="btn btn-primary" role="button" href="<? echo zen_href_link(FILENAME_ZCA_BOOTSTRAP_COLORS, 'downloadcsv=1', 'SSL') ?>"><? echo BUTTON_DOWNLOAD_CSV; ?></a>
           </div>
 <?php /* EOF CSV file */ ?>
         </div>

--- a/YOUR_ADMIN/zca_bootstrap_colors.php
+++ b/YOUR_ADMIN/zca_bootstrap_colors.php
@@ -14,16 +14,17 @@ $sqlGroup = "SELECT configuration_group_id
 
 $groupID = $db->Execute($sqlGroup);
 
+$gID = 0;
+
+// Without a valid config group present, it means the ZCA Bootstrap module isn't installed/configured yet/anymore.
 if (empty($groupID->fields['configuration_group_id'])) {
   $messageStack->add(MISSING_CONFIGURATION, 'error');
-  $gID = 0;
 } else {
   $gID = $groupID->fields['configuration_group_id'];
 }
 
 // BOF upload CSV file
-$uploadcsv = isset($_GET['uploadcsv']) ? $_GET['uploadcsv'] : '';
-if (!empty($uploadcsv)) {
+if (!empty($_GET['uploadcsv'])) {
   $file_contents = '';
   $color_list = [];
   $fail_count = 0;
@@ -98,8 +99,7 @@ if (!empty($uploadcsv)) {
 // EOF upload SQL file
 
 // BOF download CSV file
-$downloadcsv = isset($_GET['downloadcsv']) ? $_GET['downloadcsv'] : '';
-if (!empty($downloadcsv)) {
+if (!empty($_GET['downloadcsv'])) {
   $filename = 'zca_bootstrap_colors_' . date('Ymd_His') . '.csv';
   header('Content-Type: text/csv; charset=utf-8');
   header('Content-Disposition: attachment; filename=' . $filename);

--- a/YOUR_ADMIN/zca_bootstrap_colors.php
+++ b/YOUR_ADMIN/zca_bootstrap_colors.php
@@ -16,7 +16,7 @@ $groupID = $db->Execute($sqlGroup);
 
 $gID = $groupID->fields['configuration_group_id'];
 if (empty($gID)) {
-  $gID = 1;
+  $gID = 0;
   $messageStack->add(MISSING_CONFIGURATION, 'error');
 }
 

--- a/YOUR_ADMIN/zca_bootstrap_colors.php
+++ b/YOUR_ADMIN/zca_bootstrap_colors.php
@@ -16,8 +16,8 @@ $groupID = $db->Execute($sqlGroup);
 
 $gID = $groupID->fields['configuration_group_id'];
 if (empty($gID)) {
-  $gID = 0;
   $messageStack->add(MISSING_CONFIGURATION, 'error');
+  zen_redirect(zen_href_link(FILENAME_DEFAULT));
 }
 
 // BOF upload CSV file

--- a/YOUR_ADMIN/zca_bootstrap_colors.php
+++ b/YOUR_ADMIN/zca_bootstrap_colors.php
@@ -227,7 +227,7 @@ $cfg_group = $db->Execute("SELECT configuration_group_title
             <?php echo '</form>'; ?>
           </div>
           <div class="row text-right">
-            <a class="btn btn-primary" role="button" href="<? echo zen_href_link(FILENAME_ZCA_BOOTSTRAP_COLORS, 'downloadcsv=1', 'SSL') ?>"><? echo BUTTON_DOWNLOAD_CSV; ?></a>
+            <a class="btn btn-primary" role="button" href="<?php echo zen_href_link(FILENAME_ZCA_BOOTSTRAP_COLORS, 'downloadcsv=1', 'SSL') ?>"><?php echo BUTTON_DOWNLOAD_CSV; ?></a>
           </div>
 <?php /* EOF CSV file */ ?>
         </div>


### PR DESCRIPTION
I found changing the ZCA Bootstrap colors very tedious, especially when restoring the colors that I found acceptable. I added the capability to create and download a SQL file. The contents of the file can be entered via Admin -> Tools -> Install SQL Patches to restore the colors.

The zca_bootstrap_colors.php file was also updated to use admin_html_head.php