### PR TITLE
#36: Refactoring prior to correcting PHP notice

### DIFF
--- a/includes/modules/bootstrap/centerboxes/also_purchased_products.php
+++ b/includes/modules/bootstrap/centerboxes/also_purchased_products.php
@@ -2,7 +2,7 @@
 /**
  * also_purchased_products module
  * 
- * BOOTSTRAP v3.0.0
+ * BOOTSTRAP v3.1.0
  *
  * @copyright Copyright 2003-2020 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
@@ -10,63 +10,64 @@
  * @version $Id: Scott C Wilson 2020 Aug 07 Modified in v1.5.7a $
  */
 if (!defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access');
+    die('Illegal Access');
 }
 if (isset($_GET['products_id']) && SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PRODUCTS > 0 && MIN_DISPLAY_ALSO_PURCHASED > 0) {
+    $also_purchased_products = $db->ExecuteRandomMulti(sprintf(SQL_ALSO_PURCHASED, (int)$_GET['products_id'], (int)$_GET['products_id']), (int)MAX_DISPLAY_ALSO_PURCHASED);
 
-  $also_purchased_products = $db->ExecuteRandomMulti(sprintf(SQL_ALSO_PURCHASED, (int)$_GET['products_id'], (int)$_GET['products_id']), (int)MAX_DISPLAY_ALSO_PURCHASED);
+    $num_products_ordered = $also_purchased_products->RecordCount();
 
-  $num_products_ordered = $also_purchased_products->RecordCount();
+    $row = 0;
+    $col = 0;
+    $list_box_contents = array();
+    $title = '';
 
-  $row = 0;
-  $col = 0;
-  $list_box_contents = array();
-  $title = '';
+    // show only when 1 or more and equal to or greater than minimum set in admin
+    if ($num_products_ordered >= MIN_DISPLAY_ALSO_PURCHASED && $num_products_ordered > 0) {
+        if ($num_products_ordered < SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PRODUCTS) {
+            $col_width = floor(100/$num_products_ordered);
+        } else {
+            $col_width = floor(100/SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PRODUCTS);
+        }
 
-  // show only when 1 or more and equal to or greater than minimum set in admin
-  if ($num_products_ordered >= MIN_DISPLAY_ALSO_PURCHASED && $num_products_ordered > 0) {
-    if ($num_products_ordered < SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PRODUCTS) {
-      $col_width = floor(100/$num_products_ordered);
-    } else {
-      $col_width = floor(100/SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PRODUCTS);
-    }
-
-    while (!$also_purchased_products->EOF) {
-      $also_purchased_products->fields['products_name'] = zen_get_products_name($also_purchased_products->fields['products_id']);
+        while (!$also_purchased_products->EOF) {
+            $also_purchased_products->fields['products_name'] = zen_get_products_name($also_purchased_products->fields['products_id']);
       
-/** bof products price */
-    $products_price = zen_get_products_display_price($also_purchased_products->fields['products_id']);
+            /** bof products price */
+            $products_price = zen_get_products_display_price($also_purchased_products->fields['products_id']);
 
-$also_purchased_products_price = '<div class="centerBoxContentsItem-price text-center">' . $products_price . '</div>';
-/** eof products price */
+            $also_purchased_products_price = '<div class="centerBoxContentsItem-price text-center">' . $products_price . '</div>';
+            /** eof products price */
 
-/** bof products name */
-    $also_purchased_products->fields['products_name'] = zen_get_products_name($also_purchased_products->fields['products_id']);    
+            /** bof products name */
+            $also_purchased_products->fields['products_name'] = zen_get_products_name($also_purchased_products->fields['products_id']);    
     
-$also_purchased_products_name = '<div class="centerBoxContentsItem-name text-center"><a href="' . zen_href_link(zen_get_info_page($also_purchased_products->fields['products_id']), 'cPath=' . $productsInCategory[$also_purchased_products->fields['products_id']] . '&products_id=' . $also_purchased_products->fields['products_id']) . '">' . $also_purchased_products->fields['products_name'] . '</a></div>';
-/** eof products name */
+            $also_purchased_products_name = '<div class="centerBoxContentsItem-name text-center"><a href="' . zen_href_link(zen_get_info_page($also_purchased_products->fields['products_id']), 'cPath=' . $productsInCategory[$also_purchased_products->fields['products_id']] . '&products_id=' . $also_purchased_products->fields['products_id']) . '">' . $also_purchased_products->fields['products_name'] . '</a></div>';
+            /** eof products name */
 
-/** bof products image */
-if (empty($also_purchased_products->fields['products_image']) && (int)PRODUCTS_IMAGE_NO_IMAGE_STATUS === 0) {
-$also_purchased_products_image = '';
-} else {
-$also_purchased_products_image = '<div class="centerBoxContentsItem-image text-center"><a href="' . zen_href_link(zen_get_info_page($also_purchased_products->fields['products_id']), 'cPath=' . $productsInCategory[$also_purchased_products->fields['products_id']] . '&products_id=' . $also_purchased_products->fields['products_id']) . '">' . zen_image(DIR_WS_IMAGES . $also_purchased_products->fields['products_image'], $also_purchased_products->fields['products_name'], SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT) . '</a></div>';
-}
-/** eof products image */      
+            /** bof products image */
+            if (empty($also_purchased_products->fields['products_image']) && (int)PRODUCTS_IMAGE_NO_IMAGE_STATUS === 0) {
+                $also_purchased_products_image = '';
+            } else {
+                $also_purchased_products_image = '<div class="centerBoxContentsItem-image text-center"><a href="' . zen_href_link(zen_get_info_page($also_purchased_products->fields['products_id']), 'cPath=' . $productsInCategory[$also_purchased_products->fields['products_id']] . '&products_id=' . $also_purchased_products->fields['products_id']) . '">' . zen_image(DIR_WS_IMAGES . $also_purchased_products->fields['products_image'], $also_purchased_products->fields['products_name'], SMALL_IMAGE_WIDTH, SMALL_IMAGE_HEIGHT) . '</a></div>';
+            }
+            /** eof products image */
       
-      $list_box_contents[$row][$col] = array('params' => 'class="centerBoxContents card mb-3 p-3 text-center"',
-      'text' => $also_purchased_products_image . $also_purchased_products_name . $also_purchased_products_price);
+            $list_box_contents[$row][$col] = array(
+                'params' => 'class="centerBoxContents card mb-3 p-3 text-center"',
+                'text' => $also_purchased_products_image . $also_purchased_products_name . $also_purchased_products_price
+            );
 
-      $col ++;
-      if ($col > (SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PRODUCTS - 1)) {
-        $col = 0;
-        $row ++;
-      }
-      $also_purchased_products->MoveNextRandom();
+            $col++;
+            if ($col >= (int)SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PRODUCTS) {
+                $col = 0;
+                $row++;
+            }
+            $also_purchased_products->MoveNextRandom();
+        }
     }
-  }
-  if ($also_purchased_products->RecordCount() > 0 && $also_purchased_products->RecordCount() >= MIN_DISPLAY_ALSO_PURCHASED) {
-    $title = '<h4 id="alsoPurchasedCenterbox-card-header" class="centerBoxHeading card-header">' . TEXT_ALSO_PURCHASED_PRODUCTS . '</h4>';
-    $zc_show_also_purchased = true;
-  }
+    if ($also_purchased_products->RecordCount() > 0 && $also_purchased_products->RecordCount() >= MIN_DISPLAY_ALSO_PURCHASED) {
+        $title = '<h4 id="alsoPurchasedCenterbox-card-header" class="centerBoxHeading card-header">' . TEXT_ALSO_PURCHASED_PRODUCTS . '</h4>';
+        $zc_show_also_purchased = true;
+    }
 }


### PR DESCRIPTION
... as noting in the various pushes for this branch, the main correction is simply removing that `cPath` parameter from the product's link, mimicking the layout of the Zen Cart base version of the file. 