### PR TITLE
Define clearBoth class

### DIFF
--- a/includes/templates/bootstrap/css/stylesheet.css
+++ b/includes/templates/bootstrap/css/stylesheet.css
@@ -5,6 +5,11 @@
  *
  */
 
+
+.clearBoth {
+   clear: both;
+}
+
 /* This is used to re-size images */
 img{max-width:100%;height:auto;border:0;}
 
@@ -97,3 +102,4 @@ table.tabTable td {
   column-count: 2;
 }   
 }
+


### PR DESCRIPTION
This class is used in a number of template files, both in bootstrap and template_default, so it needs to be defined. 