### PR TITLE
Use billing address not shipping address

### DIFF
--- a/includes/templates/bootstrap/templates/tpl_modules_checkout_address_book.php
+++ b/includes/templates/bootstrap/templates/tpl_modules_checkout_address_book.php
@@ -17,7 +17,12 @@
  */
 require DIR_WS_MODULES . zen_get_module_directory('checkout_address_book.php');
 while (!$addresses->EOF) {
-    if ($addresses->fields['address_book_id'] == $_SESSION['sendto']) {
+    $selected = ($addresses->fields['address_book_id'] == $_SESSION['sendto']); 
+    if ($current_page_base === FILENAME_CHECKOUT_PAYMENT_ADDRESS) {
+       $selected = ($addresses->fields['address_book_id'] == $_SESSION['billto']); 
+    }
+
+    if ($selected) { 
         $primary_border = ' border-primary';
         $primary_background = ' bg-primary text-white';
         $primary_address = BOOTSTRAP_CURRENT_ADDRESS;


### PR DESCRIPTION
If you have a different shipping address from your billing address, the shipping address is shown as current when you try to change the billing address from the checkout payment page.

This is also a bug in template_default; working on a fix for that too. 