### PR TITLE
Fix WAVE error on next/prev buttons

### DIFF
--- a/includes/templates/bootstrap/templates/tpl_products_next_previous.php
+++ b/includes/templates/bootstrap/templates/tpl_products_next_previous.php
@@ -37,11 +37,11 @@
 </div>
 
 <div class="btn-group d-block d-sm-none" role="group">
-<a class="p-1" href="<?php echo zen_href_link(zen_get_info_page($previous), "cPath=$cPath&products_id=$previous"); ?>"><span class="btn btn-primary"><?php echo '<i class="fas fa-angle-left"></i>'; ?></span></a>
+<a class="p-1" href="<?php echo zen_href_link(zen_get_info_page($previous), "cPath=$cPath&products_id=$previous"); ?>" aria-label="Prev"><span class="btn btn-primary"><?php echo '<i class="fas fa-angle-left"></i>'; ?></span></a>
 
 <a class="p-1" href="<?php echo zen_href_link(FILENAME_DEFAULT, "cPath=$cPath"); ?>"><?php echo zen_image_button(BUTTON_IMAGE_RETURN_TO_PROD_LIST, BUTTON_RETURN_TO_PROD_LIST_ALT); ?></a>
 
-<a class="p-1" href="<?php echo zen_href_link(zen_get_info_page($next_item), "cPath=$cPath&products_id=$next_item"); ?>"><span class="btn btn-primary"><?php echo '<i class="fas fa-angle-right"></i>'; ?></span></a>
+<a class="p-1" href="<?php echo zen_href_link(zen_get_info_page($next_item), "cPath=$cPath&products_id=$next_item"); ?>" aria-label="Next"><span class="btn btn-primary"><?php echo '<i class="fas fa-angle-right"></i>'; ?></span></a>
 </div>
 
 <?php


### PR DESCRIPTION
You can see this error by running WAVE on John's site on a product page with next/prev buttons: 
https://jeandret.com/index.php?main_page=product_info&cPath=1_4&products_id=1
<img width="377" alt="wave" src="https://user-images.githubusercontent.com/4391638/186695496-4c0f8bea-4d87-4914-9c28-bb9d0868f523.png">

