### PR TITLE
Accessibility Fixes for Landmark and Heading structure

### DIFF
--- a/includes/modules/bootstrap/centerboxes/also_purchased_products.php
+++ b/includes/modules/bootstrap/centerboxes/also_purchased_products.php
@@ -70,7 +70,7 @@ if (isset($_GET['products_id']) && SHOW_PRODUCT_INFO_COLUMNS_ALSO_PURCHASED_PROD
         }
     }
     if ($also_purchased_products->RecordCount() > 0 && $also_purchased_products->RecordCount() >= MIN_DISPLAY_ALSO_PURCHASED) {
-        $title = '<h4 id="alsoPurchasedCenterbox-card-header" class="centerBoxHeading card-header">' . TEXT_ALSO_PURCHASED_PRODUCTS . '</h4>';
+        $title = '<h3 id="alsoPurchasedCenterbox-card-header" class="centerBoxHeading card-header">' . TEXT_ALSO_PURCHASED_PRODUCTS . '</h3>';
         $zc_show_also_purchased = true;
     }
 }

--- a/includes/modules/bootstrap/centerboxes/featured_products.php
+++ b/includes/modules/bootstrap/centerboxes/featured_products.php
@@ -98,9 +98,9 @@ if ($num_products_count > 0) {
 
     if (isset($new_products_category_id) && $new_products_category_id != 0) {
         $category_title = zen_get_category_name((int)$new_products_category_id, $_SESSION['languages_id']);
-        $title = '<h4 id="featuredCenterbox-card-header" class="centerBoxHeading card-header">' . TABLE_HEADING_FEATURED_PRODUCTS . ($category_title != '' ? ' - ' . $category_title : '') . '</h4>';
+        $title = '<h3 id="featuredCenterbox-card-header" class="centerBoxHeading card-header">' . TABLE_HEADING_FEATURED_PRODUCTS . ($category_title != '' ? ' - ' . $category_title : '') . '</h3>';
     } else {
-        $title = '<h4 id="featuredCenterbox-card-header" class="centerBoxHeading card-header">' . TABLE_HEADING_FEATURED_PRODUCTS . '</h4>';
+        $title = '<h3 id="featuredCenterbox-card-header" class="centerBoxHeading card-header">' . TABLE_HEADING_FEATURED_PRODUCTS . '</h3>';
     }
     $zc_show_featured = true;
 }

--- a/includes/modules/bootstrap/centerboxes/new_products.php
+++ b/includes/modules/bootstrap/centerboxes/new_products.php
@@ -99,9 +99,9 @@ if ($num_products_count > 0) {
     $heading_month_name = sprintf(TABLE_HEADING_NEW_PRODUCTS, zca_get_translated_month_name());
     if (!empty($new_products_category_id)) {
         $category_title = zen_get_category_name((int)$new_products_category_id, $_SESSION['languages_id']);
-        $title = '<h4 id="newCenterbox-card-header" class="centerBoxHeading card-header">' . $heading_month_name . ($category_title !== '' ? ' - ' . $category_title : '' ) . '</h4>';
+        $title = '<h3 id="newCenterbox-card-header" class="centerBoxHeading card-header">' . $heading_month_name . ($category_title !== '' ? ' - ' . $category_title : '' ) . '</h3>';
     } else {
-        $title = '<h4 id="newCenterbox-card-header" class="centerBoxHeading card-header">' . $heading_month_name . '</h4>';
+        $title = '<h3 id="newCenterbox-card-header" class="centerBoxHeading card-header">' . $heading_month_name . '</h3>';
     }
     $zc_show_new_products = true;
 }

--- a/includes/modules/bootstrap/centerboxes/specials_index.php
+++ b/includes/modules/bootstrap/centerboxes/specials_index.php
@@ -105,9 +105,9 @@ if ($num_products_count > 0) {
     $heading_month_name = sprintf(TABLE_HEADING_SPECIALS_INDEX, zca_get_translated_month_name());
     if (!empty($new_products_category_id)) {
         $category_title = zen_get_category_name((int)$new_products_category_id, $_SESSION['languages_id']);
-        $title = '<h4 id="specialCenterbox-card-header" class="centerBoxHeading card-header">' . $heading_month_name . ($category_title != '' ? ' - ' . $category_title : '' ) . '</h4>';
+        $title = '<h3 id="specialCenterbox-card-header" class="centerBoxHeading card-header">' . $heading_month_name . ($category_title != '' ? ' - ' . $category_title : '' ) . '</h3>';
     } else {
-        $title = '<h4 id="specialCenterbox-card-header" class="centerBoxHeading card-header">' . $heading_month_name . '</h4>';
+        $title = '<h3 id="specialCenterbox-card-header" class="centerBoxHeading card-header">' . $heading_month_name . '</h3>';
     }
     $zc_show_special_products = true;
 }

--- a/includes/templates/bootstrap/common/tpl_main_page.php
+++ b/includes/templates/bootstrap/common/tpl_main_page.php
@@ -91,7 +91,8 @@ if (defined('BS4_AJAX_SEARCH_ENABLE') && BS4_AJAX_SEARCH_ENABLE === 'true') {
     require $template->get_template_dir('tpl_ajax_search.php', DIR_WS_TEMPLATE, $current_page_base, 'modalboxes') . '/tpl_ajax_search.php';
 }
 ?>
-<div class="container-fluid" id="mainWrapper"> 
+<div class="container-fluid" id="mainWrapper">
+  <main>
 <?php
 // -----
 // Define the spacer-div that pushes either the "Header Position 1" banner or
@@ -300,5 +301,6 @@ if (SHOW_BANNERS_GROUP_SET6 !== '' && $banner = zen_banner_exists('dynamic', SHO
 $zco_notifier->notify('NOTIFY_FOOTER_END', $current_page);
 ?>
     <a href="#" id="back-to-top" class="btn" title="<?php echo BUTTON_BACK_TO_TOP_TITLE ?>" aria-label="<?php echo BUTTON_BACK_TO_TOP_TITLE ?>" role="button"><i aria-hidden="true" class="fas fa-chevron-circle-up"></i></a>
+</main>
 </div>
 </body>

--- a/includes/templates/bootstrap/templates/tpl_index_categories.php
+++ b/includes/templates/bootstrap/templates/tpl_index_categories.php
@@ -27,7 +27,7 @@ if ($show_welcome === true) {
 <?php
     if (SHOW_CUSTOMER_GREETING === '1') {
 ?>
-    <h3 id="indexCategories-greeting" class="greeting"><?php echo zen_customer_greeting(); ?></h3>
+    <h2 id="indexCategories-greeting" class="greeting"><?php echo zen_customer_greeting(); ?></h2>
 <?php
     }
 

--- a/includes/templates/bootstrap/templates/tpl_index_default.php
+++ b/includes/templates/bootstrap/templates/tpl_index_default.php
@@ -19,7 +19,7 @@
 <h1 id="indexDefault-pageHeading" class="pageHeading"><?php echo HEADING_TITLE; ?></h1>
 
 <?php if (SHOW_CUSTOMER_GREETING == 1) { ?>
-<h3 id="indexDefault-greeting" class="greeting"><?php echo zen_customer_greeting(); ?></h3>
+<h2 id="indexDefault-greeting" class="greeting"><?php echo zen_customer_greeting(); ?></h2>
 <?php } ?>
 
 <?php if (DEFINE_MAIN_PAGE_STATUS >= 1 and DEFINE_MAIN_PAGE_STATUS <= 2) { ?>


### PR DESCRIPTION
Other than color (working on that), accessibility checkers complain about two things on the current bootstrap home page.  Landmark(s) and Heading structure.

In the current distro, there is only need for one landmark - main.  That's taken care of with the fix for the includes/templates/bootstrap/common/tpl_main_page.php.

With Congratulations... , Welcome, and featured products in the center box, the Heading structure is currently h1, h3, and h4.  It appears that bootstrap was set to follow the welcome heading which is incorrect in 158.  Since the files in bootstrap will need to be h3 after the 158 fix, they are added here.

Merge is not needed till the correction in 158 but, with these corrections, we're all 100's in Lighthouse for the main page out-of-the-box.  example at testDOTislam786booksDOTcom