### PR TITLE
Accessibility Colors

### DIFF
--- a/YOUR_ADMIN/includes/init_includes/init_bc_config.php
+++ b/YOUR_ADMIN/includes/init_includes/init_bc_config.php
@@ -6,7 +6,7 @@
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: init_bc_config.php
- * BOOTSTRAP v3.1.3
+ * BOOTSTRAP v3.5.1
  */
 
 // -----
@@ -61,16 +61,16 @@ if (!defined('ZCA_BODY_TEXT_COLOR')) {
             ('Body Text Color', 'ZCA_BODY_TEXT_COLOR', '#000000', 'Default:#000000', " . $bccid . ", 1, now()),
             ('Body Background Color', 'ZCA_BODY_BACKGROUND_COLOR', '#ffffff', 'Default:#ffffff', " .$bccid . ", 2, now()),
             ('<b>Body Breadcrumbs Background Color</b>', 'ZCA_BODY_BREADCRUMBS_BACKGROUND_COLOR', '#cccccc', 'Default:#cccccc', " . $bccid . ", 3, now()),
-            ('<b>Body Breadcrumbs Text Color</b>', 'ZCA_BODY_BREADCRUMBS_TEXT_COLOR', '#000000', 'Default:000000', " . $bccid . ", 4, now()),
-            ('<b>Body Breadcrumbs Link Color</b>', 'ZCA_BODY_BREADCRUMBS_LINK_COLOR', '#33b5e5', 'Default:33b5e5', " . $bccid . ", 5, now()),
-            ('<b>Body Breadcrumbs Link Color on Hover</b>', 'ZCA_BODY_BREADCRUMBS_LINK_COLOR_HOVER', '#0099CC', 'Default:#0099CC', " . $bccid . ", 6, now()),
+            ('<b>Body Breadcrumbs Text Color</b>', 'ZCA_BODY_BREADCRUMBS_TEXT_COLOR', '#000000', 'Default:#000000', " . $bccid . ", 4, now()),
+            ('<b>Body Breadcrumbs Link Color</b>', 'ZCA_BODY_BREADCRUMBS_LINK_COLOR', '#115d79', 'Default:#115d79', " . $bccid . ", 5, now()),
+            ('<b>Body Breadcrumbs Link Color on Hover</b>', 'ZCA_BODY_BREADCRUMBS_LINK_COLOR_HOVER', '#003c52', 'Default:#003c52', " . $bccid . ", 6, now()),
             ('Body Products Base Price', 'ZCA_BODY_PRODUCTS_BASE_COLOR', '#000000', 'Default:#000000', " . $bccid . ", 7, now()),
             ('Body Products Normal Price', 'ZCA_BODY_PRODUCTS_NORMAL_COLOR', '#000000', 'Default:#000000', " . $bccid . ", 8, now()),
-            ('Body Products Special Price', 'ZCA_BODY_PRODUCTS_SPECIAL_COLOR', '#ff0000', 'Default:#ff0000', " . $bccid . ", 9, now()),
-            ('Body Products Price Discount Price', 'ZCA_BODY_PRODUCTS_DISCOUNT_COLOR', '#ff0000', 'Default:#ff0000', " . $bccid . ", 10, now()),
-            ('Body Products Sale Price', 'ZCA_BODY_PRODUCTS_SALE_COLOR', '#ff0000', 'Default:#ff0000', " . $bccid . ", 11, now()),
+            ('Body Products Special Price', 'ZCA_BODY_PRODUCTS_SPECIAL_COLOR', '#ad0000', 'Default:#ad0000', " . $bccid . ", 9, now()),
+            ('Body Products Price Discount Price', 'ZCA_BODY_PRODUCTS_DISCOUNT_COLOR', '#ad0000', 'Default:#ad0000', " . $bccid . ", 10, now()),
+            ('Body Products Sale Price', 'ZCA_BODY_PRODUCTS_SALE_COLOR', '#ad0000', 'Default:#ad0000', " . $bccid . ", 11, now()),
             ('Body Products Free Price', 'ZCA_BODY_PRODUCTS_FREE_COLOR', '#0000ff', 'Default:#0000ff', " . $bccid . ", 12, now()),
-            ('<b>Body Form Placeholder</b>', 'ZCA_BODY_PLACEHOLDER', '#ff0000', 'Default:#ff0000', " . $bccid . ", 13, now())"
+            ('<b>Body Form Placeholder</b>', 'ZCA_BODY_PLACEHOLDER', '#ad0000', 'Default:#ad0000', " . $bccid . ", 13, now())"
     );
 
     /* ZCA Bootstrap Template LINKS & BUTTONS Colors */
@@ -78,22 +78,25 @@ if (!defined('ZCA_BODY_TEXT_COLOR')) {
         "INSERT INTO " . TABLE_CONFIGURATION . "
             (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added)
          VALUES
-            ('A Link Color', 'ZCA_BUTTON_LINK_COLOR', '#05a5cb', 'Default:#05a5cb', " . $bccid . ", 14, now()),
-            ('A Link Color on Hover', 'ZCA_BUTTON_LINK_COLOR_HOVER', '#0099CC', 'Default:#0099CC', " . $bccid . ", 15, now()),
-            ('<b>Button Text Color</b>', 'ZCA_BUTTON_TEXT_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 16, now()),
-            ('<b>Button Text Color on Hover</b>', 'ZCA_BUTTON_TEXT_COLOR_HOVER', '#cccccc', 'Default:#cccccc', " . $bccid . ", 17, now()),
-            ('<b>Button Color</b>', 'ZCA_BUTTON_COLOR', '#33b5e5', 'Default:#33b5e5', " . $bccid . ", 18, now()),
-            ('<b>Button Color on Hover</b>', 'ZCA_BUTTON_COLOR_HOVER', '#0099CC', 'Default:#0099CC', " . $bccid . ", 19, now()),
-            ('<b>Button Border Color</b>', 'ZCA_BUTTON_BORDER_COLOR', '#33b5e5', 'Default:#33b5e5', " . $bccid . ", 20, now()),
-            ('<b>Button Border Color on Hover</b>', 'ZCA_BUTTON_BORDER_COLOR_HOVER', '#0099CC', 'Default:#0099CC', " . $bccid . ", 21, now()),
-            ('Pagination Button Text Color', 'ZCA_BUTTON_PAGEINATION_TEXT_COLOR', '#000000', 'Default:#000000', " . $bccid . ", 22, now()),
-            ('Pagination Button Text Color on Hover', 'ZCA_BUTTON_PAGEINATION_TEXT_COLOR_HOVER', '#ffffff', 'Default:#ffffff', " . $bccid . ", 23, now()),
-            ('Pagination Button Color', 'ZCA_BUTTON_PAGEINATION_COLOR', '#cccccc', 'Default:#cccccc', " . $bccid . ", 24, now()),
-            ('Pagination Button Color on Hover', 'ZCA_BUTTON_PAGEINATION_COLOR_HOVER', '#0099CC', 'Default:#0099CC', " . $bccid . ", 25, now()),
-            ('Pagination Button Border Color', 'ZCA_BUTTON_PAGEINATION_BORDER_COLOR', '#cccccc', 'Default:#cccccc', " . $bccid . ", 26, now()),
-            ('Pagination Button Border Color on Hover', 'ZCA_BUTTON_PAGEINATION_BORDER_COLOR_HOVER', '#0099CC', 'Default:#0099CC', " . $bccid . ", 27, now()),
-            ('Pagination Active Button Text Color', 'ZCA_BUTTON_PAGEINATION_ACTIVE_TEXT_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 28, now()),
-            ('Pagination Active Button Color', 'ZCA_BUTTON_PAGEINATION_ACTIVE_COLOR', '#33b5e5', 'Default:#33b5e5', " . $bccid . ", 29, now())"
+            ('A Link Color', 'ZCA_BUTTON_LINK_COLOR', '#0000a0', 'Default:#0000a0', " . $bccid . ", 20, now()),
+            ('A Link Color on Hover', 'ZCA_BUTTON_LINK_COLOR_HOVER', '#0056b3', 'Default:#0056b3', " . $bccid . ", 21, now()),
+            ('<b>Button Text Color</b>', 'ZCA_BUTTON_TEXT_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 22, now()),
+            ('<b>Button Text Color on Hover</b>', 'ZCA_BUTTON_TEXT_COLOR_HOVER', '#0056b3', 'Default:#0056b3', " . $bccid . ", 23, now()),
+            ('<b>Button Color</b>', 'ZCA_BUTTON_COLOR', '#007faf', 'Default:#007faf', " . $bccid . ", 24, now()),
+            ('<b>Button Color on Hover</b>', 'ZCA_BUTTON_COLOR_HOVER', '#ffffff', 'Default:#ffffff', " . $bccid . ", 25, now()),
+            ('<b>Button Border Color</b>', 'ZCA_BUTTON_BORDER_COLOR', '#007faf', 'Default:#007faf', " . $bccid . ", 26, now()),
+            ('<b>Button Border Color on Hover</b>', 'ZCA_BUTTON_BORDER_COLOR_HOVER', '#ad0000', 'Default:#ad0000', " . $bccid . ", 27, now()),
+            ('Pagination Button Text Color', 'ZCA_BUTTON_PAGEINATION_TEXT_COLOR', '#000000', 'Default:#000000', " . $bccid . ", 28, now()),
+            ('Pagination Button Text Color on Hover', 'ZCA_BUTTON_PAGEINATION_TEXT_COLOR_HOVER', '#ffffff', 'Default:#ffffff', " . $bccid . ", 29, now()),
+            ('Pagination Button Color', 'ZCA_BUTTON_PAGEINATION_COLOR', '#cccccc', 'Default:#cccccc', " . $bccid . ", 30, now()),
+            ('Pagination Button Color on Hover', 'ZCA_BUTTON_PAGEINATION_COLOR_HOVER', '#0099CC', 'Default:#0099CC', " . $bccid . ", 31, now()),
+            ('Pagination Button Border Color', 'ZCA_BUTTON_PAGEINATION_BORDER_COLOR', '#cccccc', 'Default:#cccccc', " . $bccid . ", 32, now()),
+            ('Pagination Button Border Color on Hover', 'ZCA_BUTTON_PAGEINATION_BORDER_COLOR_HOVER', '#0099CC', 'Default:#0099CC', " . $bccid . ", 33, now()),
+            ('Pagination Active Button Text Color', 'ZCA_BUTTON_PAGEINATION_ACTIVE_TEXT_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 34, now()),
+            ('Pagination Active Button Color', 'ZCA_BUTTON_PAGEINATION_ACTIVE_COLOR', '#007faf', 'Default:#007faf', " . $bccid . ", 35, now()),
+            ('Active Link Text Color', 'ZCA_ACTIVE_LINK_COLOR', '#cc3333', 'Default:#cc3333', " . $bccid . ", 36, now()),
+            ('Active Link Background Color', 'ZCA_ACTIVE_LINK_BACKGROUND_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 37, now()),
+            ('Active Link Border Color', 'ZCA_ACTIVE_LINK_BORDER_COLOR', '#cc3333', 'Default:#cc3333', " . $bccid . ", 38, now())"
     );
 
     /* ZCA Bootstrap Template HEADER Colors */
@@ -101,24 +104,29 @@ if (!defined('ZCA_BODY_TEXT_COLOR')) {
         "INSERT INTO " . TABLE_CONFIGURATION . "
             (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added)
          VALUES
-            ('<b>Header Wrapper Background Color</b>', 'ZCA_HEADER_WRAPPER_BACKGROUND_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 30, now()),
-            ('Header Tagline Text Color', 'ZCA_HEADER_TAGLINE_TEXT_COLOR', '#000000', 'Default:#000000', " . $bccid . ", 31, now()),
-            ('<b>Header Nav Bar Color</b>', 'ZCA_HEADER_NAV_BAR_BACKGROUND_COLOR', '#333333', 'Default:#333333', " . $bccid . ", 32, now()),
-            ('<b>Header Nav Bar Link Color</b>', 'ZCA_HEADER_NAVBAR_LINK_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 33, now()),
-            ('<b>Header Nav Bar Link Color on Hover</b>', 'ZCA_HEADER_NAVBAR_LINK_COLOR_HOVER', '#cccccc', 'Default:#cccccc', " . $bccid . ", 34, now()),
-            ('<b>Header Nav Bar Button Text Color</b>', 'ZCA_HEADER_NAVBAR_BUTTON_TEXT_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 35, now()),
-            ('<b>Header Nav Bar Button Text Color on Hover</b>', 'ZCA_HEADER_NAVBAR_BUTTON_TEXT_COLOR_HOVER', '#cccccc', 'Default:#cccccc', " . $bccid . ", 36, now()),
-            ('<b>Header Nav Bar Button Color</b>', 'ZCA_HEADER_NAVBAR_BUTTON_COLOR', '#343a40', 'Default:#343a40', " . $bccid . ", 37, now()),
-            ('<b>Header Nav Bar Button Color on Hover</b>', 'ZCA_HEADER_NAVBAR_BUTTON_COLOR_HOVER', '#919aa1', 'Default:#919aa1', " . $bccid . ", 38, now()),
-            ('<b>Header Nav Bar Button Border Color</b>', 'ZCA_HEADER_NAVBAR_BUTTON_BORDER_COLOR', '#343a40', 'Default:#343a40', " . $bccid . ", 39, now()),
-            ('<b>Header Nav Bar Border Color on Hover</b>', 'ZCA_HEADER_NAVBAR_BUTTON_BORDER_COLOR_HOVER', '#919aa1', 'Default:#919aa1', " . $bccid . ", 40, now()),
-            ('Header Category Tabs Text Color', 'ZCA_HEADER_TABS_TEXT_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 41, now()),
-            ('Header Category Tabs Text Color on Hover', 'ZCA_HEADER_TABS_TEXT_COLOR_HOVER', '#cccccc', 'Default:#cccccc', " . $bccid . ", 42, now()),
-            ('Header Category Tabs Background Color', 'ZCA_HEADER_TABS_COLOR', '#33b5e5', 'Default:#33b5e5', " . $bccid . ", 43, now()),
-            ('Header Category Tabs Background Color on Hover', 'ZCA_HEADER_TABS_COLOR_HOVER', '#0099CC', 'Default:#0099CC', " . $bccid . ", 44, now()),
-            ('<b>Header EZ-Page Bar Background Color</b>', 'ZCA_HEADER_EZPAGE_BACKGROUND_COLOR', '#464646', 'Default:#464646', " . $bccid . ", 45, now()),
-            ('<b>Header EZ-Page Bar Link Color</b>', 'ZCA_HEADER_EZPAGE_LINK_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 46, now()),
-            ('<b>Header EZ-Page Bar Link Color on Hover</b>', 'ZCA_HEADER_EZPAGE_LINK_COLOR_HOVER', '#cccccc', 'Default:#cccccc', " . $bccid . ", 47, now())"
+            ('<b>Header Wrapper Background Color</b>', 'ZCA_HEADER_WRAPPER_BACKGROUND_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 40, now()),
+            ('Header Tagline Text Color', 'ZCA_HEADER_TAGLINE_TEXT_COLOR', '#000000', 'Default:#000000', " . $bccid . ", 41, now()),
+            ('<b>Header Nav Bar Background Color</b>', 'ZCA_HEADER_NAV_BAR_BACKGROUND_COLOR', '#333333', 'Default:#333333', " . $bccid . ", 42, now()),
+            ('<b>Header Nav Bar Link Color</b>', 'ZCA_HEADER_NAVBAR_LINK_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 43, now()),
+            ('<b>Header Nav Bar Link Color on Hover</b>', 'ZCA_HEADER_NAVBAR_LINK_COLOR_HOVER', '#cccccc', 'Default:#cccccc', " . $bccid . ", 44, now()),
+            ('<b>Header Nav Bar Button Text Color</b>', 'ZCA_HEADER_NAVBAR_BUTTON_TEXT_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 45, now()),
+            ('<b>Header Nav Bar Button Text Color on Hover</b>', 'ZCA_HEADER_NAVBAR_BUTTON_TEXT_COLOR_HOVER', '#cccccc', 'Default:#cccccc', " . $bccid . ", 46, now()),
+            ('<b>Header Nav Bar Button Color</b>', 'ZCA_HEADER_NAVBAR_BUTTON_COLOR', '#343a40', 'Default:#343a40', " . $bccid . ", 47, now()),
+            ('<b>Header Nav Bar Button Color on Hover</b>', 'ZCA_HEADER_NAVBAR_BUTTON_COLOR_HOVER', '#919aa1', 'Default:#919aa1', " . $bccid . ", 48, now()),
+            ('<b>Header Nav Bar Button Border Color</b>', 'ZCA_HEADER_NAVBAR_BUTTON_BORDER_COLOR', '#343a40', 'Default:#343a40', " . $bccid . ", 49, now()),
+            ('<b>Header Nav Bar Border Color on Hover</b>', 'ZCA_HEADER_NAVBAR_BUTTON_BORDER_COLOR_HOVER', '#919aa1', 'Default:#919aa1', " . $bccid . ", 50, now()),
+            ('Header Category Tabs Text Color', 'ZCA_HEADER_TABS_TEXT_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 51, now()),
+            ('Header Category Tabs Text Color on Hover', 'ZCA_HEADER_TABS_TEXT_COLOR_HOVER', '#007faf', 'Default:#007af', " . $bccid . ", 52, now()),
+            ('Header Category Tabs Border Color on Hover', 'ZCA_HEADER_TABS_BORDER_COLOR_HOVER', '#007faf', 'Default:#007faf', " . $bccid . ", 53, now()),
+            ('Header Category Tabs Background Color', 'ZCA_HEADER_TABS_BACKGROUND_COLOR', '#007faf', 'Default:#007faf', " . $bccid . ", 54, now()),
+            ('Header Category Tabs Background Color on Hover', 'ZCA_HEADER_TABS_BACKGROUND_COLOR_HOVER', '#ffffff', 'Default:#ffffff', " . $bccid . ", 55, now()),
+            ('Header Category Tabs Active Color', 'ZCA_HEADER_TABS_ACTIVE_COLOR', '#ad0000', 'Default:#ad0000', " . $bccid . ", 56, now()),
+            ('Header Category Tabs Active Background Color', 'ZCA_HEADER_TABS_ACTIVE_BACKGROUND_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 57, now()),
+            ('Header Category Tabs Active Border Color', 'ZCA_HEADER_TABS_ACTIVE_BORDER_COLOR', '#ad0000', 'Default:#ad0000', " . $bccid . ", 58, now()),
+            ('<b>Header EZ-Page Bar Background Color</b>', 'ZCA_HEADER_EZPAGE_BACKGROUND_COLOR', '#464646', 'Default:#464646', " . $bccid . ", 59, now()),
+            ('<b>Header EZ-Page Bar Link Color</b>', 'ZCA_HEADER_EZPAGE_LINK_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 60, now()),
+            ('<b>Header EZ-Page Bar Link Color on Hover</b>', 'ZCA_HEADER_EZPAGE_LINK_COLOR_HOVER', '#464646', 'Default:#464646', " . $bccid . ", 61, now()),
+            ('<b>Header EZ-Page Bar Background Color on Hover</b>', 'ZCA_HEADER_EZPAGE_BACKGROUND_COLOR_HOVER', '#ffffff', 'Default:#ffffff', " . $bccid . ", 62, now())"
     );
 
     /* ZCA Bootstrap Template FOOTER Colors */
@@ -126,11 +134,11 @@ if (!defined('ZCA_BODY_TEXT_COLOR')) {
         "INSERT INTO " . TABLE_CONFIGURATION . "
             (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added)
          VALUES
-            ('Footer Wrapper Text Color', 'ZCA_FOOTER_WRAPPER_TEXT_COLOR', '#000000', 'Default:#000000', " . $bccid . ", 48, now()),
-            ('Footer Wrapper Background Color', 'ZCA_FOOTER_WRAPPER_BACKGROUND_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 49, now()),
-            ('<b>Footer EZ-Page Bar Background Color</b>', 'ZCA_FOOTER_EZPAGE_BACKGROUND_COLOR', '#464646', 'Default:#464646', " . $bccid . ", 50, now()),
-            ('<b>Footer EZ-Page Bar Link Color</b>', 'ZCA_FOOTER_EZPAGE_LINK_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 51, now()),
-            ('<b>Footer EZ-Page Bar Link Color on Hover</b>', 'ZCA_FOOTER_EZPAGE_LINK_COLOR_HOVER', '#cccccc', 'Default:#cccccc', " . $bccid . ", 52, now())"
+            ('Footer Wrapper Text Color', 'ZCA_FOOTER_WRAPPER_TEXT_COLOR', '#000000', 'Default:#000000', " . $bccid . ", 70, now()),
+            ('Footer Wrapper Background Color', 'ZCA_FOOTER_WRAPPER_BACKGROUND_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 71, now()),
+            ('<b>Footer EZ-Page Bar Background Color</b>', 'ZCA_FOOTER_EZPAGE_BACKGROUND_COLOR', '#464646', 'Default:#464646', " . $bccid . ", 72, now()),
+            ('<b>Footer EZ-Page Bar Link Color</b>', 'ZCA_FOOTER_EZPAGE_LINK_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 73, now()),
+            ('<b>Footer EZ-Page Bar Link Color on Hover</b>', 'ZCA_FOOTER_EZPAGE_LINK_COLOR_HOVER', '#cccccc', 'Default:#cccccc', " . $bccid . ", 74, now())"
     );
 
     /* ZCA Bootstrap Template SIDEBOXES Colors */
@@ -138,20 +146,24 @@ if (!defined('ZCA_BODY_TEXT_COLOR')) {
         "INSERT INTO " . TABLE_CONFIGURATION . "
             (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added)
          VALUES
-            ('Sidebox Background Color', 'ZCA_SIDEBOX_BACKGROUND_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 53, now()),
-            ('Sidebox Text Color', 'ZCA_SIDEBOX_TEXT_COLOR', '#000000', 'Default:#000000', " . $bccid . ", 54, now()),
-            ('Sidebox Link Color', 'ZCA_SIDEBOX_LINK_COLOR', '#33b5e5', 'Default:#33b5e5', " . $bccid . ", 55, now()),
-            ('Sidebox Link Color on Hover', 'ZCA_SIDEBOX_LINK_COLOR_HOVER', '#0099CC', 'Default:#0099CC', " . $bccid . ", 56, now()),
-            ('Sidebox Link Background Color', 'ZCA_SIDEBOX_LINK_BACKGROUND_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 57, now()),
-            ('Sidebox Link Background Color on Hover', 'ZCA_SIDEBOX_LINK_BACKGROUND_COLOR_HOVER', '#efefef', 'Default:#ffffff', " . $bccid . ", 58, now()),
-            ('<b>Sidebox Product Card Background Color</b>', 'ZCA_SIDEBOX_CARD_BACKGROUND_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 59, now()),
-            ('<b>Sidebox Product Card Background Color on Hover</b>', 'ZCA_SIDEBOX_CARD_BACKGROUND_COLOR_HOVER', '#efefef', 'Default:#efefef', " . $bccid . ", 60, now()),
-            ('Sidebox Header Background Color', 'ZCA_SIDEBOX_HEADER_BACKGROUND_COLOR', '#333333', 'Default:#333333', " . $bccid . ", 61, now()),
-            ('Sidebox Header Text Color', 'ZCA_SIDEBOX_HEADER_TEXT_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 62, now()),
-            ('Sidebox Header Link Color', 'ZCA_SIDEBOX_HEADER_LINK_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 63, now()),
-            ('Sidebox Header Link Color on Hover', 'ZCA_SIDEBOX_HEADER_LINK_COLOR_HOVER', '#cccccc', 'Default:#cccccc', " . $bccid . ", 64, now()),
-            ('<b>Sidebox Category Counts Color</b>', 'ZCA_SIDEBOX_COUNTS_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 65, now()),
-            ('<b>Sidebox Category Counts Background Color</b>', 'ZCA_SIDEBOX_COUNTS_BACKGROUND_COLOR', '#33b5e5', 'Default:33b5e5', " . $bccid . ", 66, now())"
+            ('Sidebox Background Color', 'ZCA_SIDEBOX_BACKGROUND_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 80, now()),
+            ('Sidebox Text Color', 'ZCA_SIDEBOX_TEXT_COLOR', '#000000', 'Default:#000000', " . $bccid . ", 81, now()),
+            ('Sidebox Link Color', 'ZCA_SIDEBOX_LINK_COLOR', '#0000a0', 'Default:#0000a0', " . $bccid . ", 82, now()),
+            ('Sidebox Link Color on Hover', 'ZCA_SIDEBOX_LINK_COLOR_HOVER', '#003975', 'Default:#003975', " . $bccid . ", 83, now()),
+            ('Sidebox Link Background Color', 'ZCA_SIDEBOX_LINK_BACKGROUND_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 84, now()),
+            ('Sidebox Link Background Color on Hover', 'ZCA_SIDEBOX_LINK_BACKGROUND_COLOR_HOVER', '#cccccc', 'Default:#cccccc', " . $bccid . ", 85, now()),
+            ('<b>Sidebox Product Card Background Color</b>', 'ZCA_SIDEBOX_CARD_BACKGROUND_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 86, now()),
+            ('<b>Sidebox Product Card Background Color on Hover</b>', 'ZCA_SIDEBOX_CARD_BACKGROUND_COLOR_HOVER', '#cccccc', 'Default:#cccccc', " . $bccid . ", 87, now()),
+            ('Sidebox Header Background Color', 'ZCA_SIDEBOX_HEADER_BACKGROUND_COLOR', '#333333', 'Default:#333333', " . $bccid . ", 88, now()),
+            ('Sidebox Header Text Color', 'ZCA_SIDEBOX_HEADER_TEXT_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 89, now()),
+            ('Sidebox Header Link Color', 'ZCA_SIDEBOX_HEADER_LINK_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 90, now()),
+            ('Sidebox Header Link Color on Hover', 'ZCA_SIDEBOX_HEADER_LINK_COLOR_HOVER', '#cccccc', 'Default:#cccccc', " . $bccid . ", 91, now()),
+            ('<b>Sidebox Category Counts Color</b>', 'ZCA_SIDEBOX_COUNTS_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 92, now()),
+            ('<b>Sidebox List Group Item Actiive Link Color</b>', 'ZCA_SIDEBOX_GROUP_ITEM_ACTIVE_LINK_COLOR', '#007faf', 'Default:#007faf', " . $bccid . ", 93, now()),
+            ('<b>Sidebox Category Products Color</b>', 'ZCA_SIDEBOX_CATEGORY_PRODUCTS_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 94, now()),
+            ('<b>Sidebox Category Counts Background Color</b>', 'ZCA_SIDEBOX_COUNTS_BACKGROUND_COLOR', '#007faf', 'Default:#007faf', " . $bccid . ", 95, now()),
+            ('<b>Rating Star Color</b>', 'ZCA_RATING_STAR_COLOR', '#efa31d', 'Default:#efa31d', " . $bccid . ", 96, now()),
+            ('<b>Rating Star Background Color</b>', 'ZCA_RATING_STAR_BACKGROUND_COLOR', '#000000', 'Default:#000000', " . $bccid . ", 97, now())"
     );
 
     /* ZCA Bootstrap Template CENTERBOXES Colors */
@@ -159,12 +171,12 @@ if (!defined('ZCA_BODY_TEXT_COLOR')) {
         "INSERT INTO " . TABLE_CONFIGURATION . "
             (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added)
          VALUES
-            ('Centerbox Background Color', 'ZCA_CENTERBOX_BACKGROUND_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 67, now()),
-            ('Centerbox Text Color', 'ZCA_CENTERBOX_TEXT_COLOR', '#000000', 'Default:#000000', " . $bccid . ", 68, now()),
-            ('<b>Centerbox Product Card Background Color</b>', 'ZCA_CENTERBOX_CARD_BACKGROUND_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 69, now()),
-            ('<b>Centerbox Product Card Background Color on Hover</b>', 'ZCA_CENTERBOX_CARD_BACKGROUND_COLOR_HOVER', '#efefef', 'Default:#efefef', " . $bccid . ", 70, now()),
-            ('Centerbox Header Background Color', 'ZCA_CENTERBOX_HEADER_BACKGROUND_COLOR', '#333333', 'Default:#333333', " . $bccid . ", 71, now()),
-            ('Centerbox Header Text Color', 'ZCA_CENTERBOX_HEADER_TEXT_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 72, now())"
+            ('Centerbox Background Color', 'ZCA_CENTERBOX_BACKGROUND_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 100, now()),
+            ('Centerbox Text Color', 'ZCA_CENTERBOX_TEXT_COLOR', '#000000', 'Default:#000000', " . $bccid . ", 101, now()),
+            ('<b>Centerbox Product Card Background Color</b>', 'ZCA_CENTERBOX_CARD_BACKGROUND_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 102, now()),
+            ('<b>Centerbox Product Card Background Color on Hover</b>', 'ZCA_CENTERBOX_CARD_BACKGROUND_COLOR_HOVER', '#efefef', 'Default:#efefef', " . $bccid . ", 103, now()),
+            ('Centerbox Header Background Color', 'ZCA_CENTERBOX_HEADER_BACKGROUND_COLOR', '#333333', 'Default:#333333', " . $bccid . ", 104, now()),
+            ('Centerbox Header Text Color', 'ZCA_CENTERBOX_HEADER_TEXT_COLOR', '#ffffff', 'Default:#ffffff', " . $bccid . ", 105, now())"
     );
 
     $messageStack->add('ZCA Bootstrap Colors install completed!', 'success');
@@ -183,9 +195,9 @@ if (!defined('ZCA_ADD_TO_CART_BACKGROUND_COLOR')) {
         "INSERT INTO " . TABLE_CONFIGURATION . "
             (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added)
          VALUES
-            ('Add-to-Cart Card Background Color', 'ZCA_ADD_TO_CART_BACKGROUND_COLOR', '#00C851', 'Default: #00C851', " . $bccid . ", 100, now()),
-            ('Add-to-Cart Card Text Color', 'ZCA_ADD_TO_CART_TEXT_COLOR', '#fff', 'Default: #fff', " . $bccid . ", 101, now()),
-            ('Add-to-Cart Card Border Color', 'ZCA_ADD_TO_CART_BORDER_COLOR', '#00C851', 'Default: #00C851', " . $bccid . ", 102, now())"
+            ('Add-to-Cart Card Background Color', 'ZCA_ADD_TO_CART_BACKGROUND_COLOR', '#008a13', 'Default: #008a13', " . $bccid . ", 120, now()),
+            ('Add-to-Cart Card Text Color', 'ZCA_ADD_TO_CART_TEXT_COLOR', '#ffffff', 'Default: #ffffff', " . $bccid . ", 121, now()),
+            ('Add-to-Cart Card Border Color', 'ZCA_ADD_TO_CART_BORDER_COLOR', '#008a13', 'Default: #008a13', " . $bccid . ", 122, now())"
     );
     $zca_colors_updated = true;
 }
@@ -194,14 +206,34 @@ if (!defined('ZCA_BUTTON_IN_CART_BACKGROUND_COLOR')) {
         "INSERT INTO " . TABLE_CONFIGURATION . "
             (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added)
          VALUES
-            ('Add-to-Cart Button Background Color', 'ZCA_BUTTON_IN_CART_BACKGROUND_COLOR', '#00C851', 'Default: #00C851', " . $bccid . ", 120, now()),
-            ('Add-to-Cart Button Text Color', 'ZCA_BUTTON_IN_CART_TEXT_COLOR', '#fff', 'Default: #fff', " . $bccid . ", 121, now()),
-            ('Add-to-Cart Button Background Color on Hover', 'ZCA_BUTTON_IN_CART_BACKGROUND_COLOR_HOVER', '#007E33', 'Default: #007E33', " . $bccid . ", 122, now()),
-            ('Add-to-Cart Button Text Color on Hover', 'ZCA_BUTTON_IN_CART_TEXT_COLOR_HOVER', '#fff', 'Default: #fff', " . $bccid . ", 123, now()),
-            ('Add-Selected Button Background Color', 'ZCA_BUTTON_ADD_SELECTED_BACKGROUND_COLOR', '#00C851', 'Default: #00C851', " . $bccid . ", 120, now()),
-            ('Add-Selected Button Text Color', 'ZCA_BUTTON_ADD_SELECTED_TEXT_COLOR', '#fff', 'Default: #fff', " . $bccid . ", 121, now()),
-            ('Add-Selected Button Background Color on Hover', 'ZCA_BUTTON_ADD_SELECTED_BACKGROUND_COLOR_HOVER', '#007E33', 'Default: #007E33', " . $bccid . ", 122, now()),
-            ('Add-Selected Button Text Color on Hover', 'ZCA_BUTTON_ADD_SELECTED_TEXT_COLOR_HOVER', '#fff', 'Default: #fff', " . $bccid . ", 123, now())"
+            ('Add-to-Cart Button Background Color', 'ZCA_BUTTON_IN_CART_BACKGROUND_COLOR', '#008a13', 'Default: #008a13', " . $bccid . ", 130, now()),
+            ('Add-to-Cart Button Text Color', 'ZCA_BUTTON_IN_CART_TEXT_COLOR', '#ffffff', 'Default: #ffffff', " . $bccid . ", 131, now()),
+            ('Add-to-Cart Button Background Color on Hover', 'ZCA_BUTTON_IN_CART_BACKGROUND_COLOR_HOVER', '#007E33', 'Default: #007E33', " . $bccid . ", 132, now()),
+            ('Add-to-Cart Button Text Color on Hover', 'ZCA_BUTTON_IN_CART_TEXT_COLOR_HOVER', '#ffffff', 'Default: #ffffff', " . $bccid . ", 133, now()),
+            ('Add-Selected Button Background Color', 'ZCA_BUTTON_ADD_SELECTED_BACKGROUND_COLOR', '#008a13', 'Default: #008a13', " . $bccid . ", 134, now()),
+            ('Add-Selected Button Text Color', 'ZCA_BUTTON_ADD_SELECTED_TEXT_COLOR', '#ffffff', 'Default: #ffffff', " . $bccid . ", 135, now()),
+            ('Add-Selected Button Background Color on Hover', 'ZCA_BUTTON_ADD_SELECTED_BACKGROUND_COLOR_HOVER', '#007E33', 'Default: #007E33', " . $bccid . ", 136, now()),
+            ('Add-Selected Button Text Color on Hover', 'ZCA_BUTTON_ADD_SELECTED_TEXT_COLOR_HOVER', '#ffffff', 'Default: #ffffff', " . $bccid . ", 137, now()),
+            ('Review Stars Color', 'ZCA_REVIEW_STARS_COLOR', '#f9e3b6', 'Default: #ffffff', " . $bccid . ", 138, now()),
+            ('Review Stars Background Color', 'ZCA_REVIEW_STARS_BACKGROUND_COLOR', '#f9e3b6', 'Default: #ffffff', " . $bccid . ", 139, now()),
+            ('Standard Checkout Progress Bar Background Color', 'ZCA_STD_CHECKOUT_PROGRESS_BAR_COLOR', '#008a13', 'Default: #008a13', " . $bccid . ", 140, now())"
+    );
+    $zca_colors_updated = true;
+}
+
+// -----
+// Additional selections added by dbltoe - Not needed if Ajax Search is not used
+//
+
+if (!defined('ZCA_SEARCH_SUG_CONTENT_BORDER_COLOR')) {
+    $db->Execute(
+        "INSERT INTO " . TABLE_CONFIGURATION . "
+            (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added)
+         VALUES
+            ('<b>Ajax Search Window Item Border Color -- If Turned On in Bootstrap Configuration<b>', 'ZCA_SEARCH_SUG_CONTENT_BORDER_COLOR', '#5c4000', 'Default: #000000', " . $bccid . ", 150, now()),
+            ('Ajax Search Item Background Color on Hover', 'ZCA_SEARCH_SUG_CONTENT_BACKGROUND_COLOR_HOVER', '#c4a484', 'Default: #007faf', " . $bccid . ", 151, now()),
+            ('Ajax Search Item Main Shadow Color on Hover', 'ZCA_SEARCH_SUG_HOVER_SHADOW1', '#c4a484', 'Default: #dff4ff', " . $bccid . ", 152, now()),
+            ('Ajax Search Item Secondary Shadow Color on Hover', 'ZCA_SEARCH_SUG_HOVER_SHADOW2', '#f9e3b6', 'Default: #ffffff', " . $bccid . ", 153, now())"
     );
     $zca_colors_updated = true;
 }
@@ -217,10 +249,10 @@ $bc_check = $db->ExecuteNoCache(
       LIMIT 1"
 );
 if (!$bc_check->EOF) {
-    $db->Execute("UPDATE " . TABLE_CONFIGURATION . " SET sort_order = 130 WHERE configuration_key = 'ZCA_BUTTON_ADD_SELECTED_BACKGROUND_COLOR' LIMIT 1");
-    $db->Execute("UPDATE " . TABLE_CONFIGURATION . " SET sort_order = 131 WHERE configuration_key = 'ZCA_BUTTON_ADD_SELECTED_TEXT_COLOR' LIMIT 1");
-    $db->Execute("UPDATE " . TABLE_CONFIGURATION . " SET sort_order = 132 WHERE configuration_key = 'ZCA_BUTTON_ADD_SELECTED_BACKGROUND_COLOR_HOVER' LIMIT 1");
-    $db->Execute("UPDATE " . TABLE_CONFIGURATION . " SET sort_order = 133 WHERE configuration_key = 'ZCA_BUTTON_ADD_SELECTED_TEXT_COLOR_HOVER' LIMIT 1");
+    $db->Execute("UPDATE " . TABLE_CONFIGURATION . " SET sort_order = 150 WHERE configuration_key = 'ZCA_BUTTON_ADD_SELECTED_BACKGROUND_COLOR' LIMIT 1");
+    $db->Execute("UPDATE " . TABLE_CONFIGURATION . " SET sort_order = 151 WHERE configuration_key = 'ZCA_BUTTON_ADD_SELECTED_TEXT_COLOR' LIMIT 1");
+    $db->Execute("UPDATE " . TABLE_CONFIGURATION . " SET sort_order = 152 WHERE configuration_key = 'ZCA_BUTTON_ADD_SELECTED_BACKGROUND_COLOR_HOVER' LIMIT 1");
+    $db->Execute("UPDATE " . TABLE_CONFIGURATION . " SET sort_order = 153 WHERE configuration_key = 'ZCA_BUTTON_ADD_SELECTED_TEXT_COLOR_HOVER' LIMIT 1");
 }
 
 if ($zca_colors_updated) {

--- a/includes/templates/bootstrap/css/stylesheet_zca_colors.php
+++ b/includes/templates/bootstrap/css/stylesheet_zca_colors.php
@@ -12,7 +12,7 @@ a:hover {color: <?php echo ZCA_BUTTON_LINK_COLOR_HOVER; ?>;}
 .required-info, .alert {color: <?php echo ZCA_BODY_PLACEHOLDER; ?>;}
 
 /* Nav Bar Active Links */
-.activeLink {color: <?php echo ZCA_ACTIVE_LINK_COLOR; ?> !important;background-color: <?php echo ZCA_ACTIVE_LINK_BACKGROUND_COLOR; ?> !important;border: 2px solid <?php echo ZCA_ACTIVE_LINK_BORDER_COLOR; ?> !important;}
+.activeLink {color: <?php echo ZCA_ACTIVE_LINK_COLOR; ?> !important;background-color: <?php echo ZCA_ACTIVE_LINK_BACKGROUND_COLOR; ?> !important;}
 
 /* for button specific colors, examples are in stylesheet_css_buttons.css */
 /* buttons */
@@ -41,7 +41,7 @@ nav.navbar .navbar-toggler:hover {color: <?php echo ZCA_HEADER_NAVBAR_BUTTON_TEX
 
 /* header category tabs */
 #navCatTabs a {color: <?php echo ZCA_HEADER_TABS_TEXT_COLOR; ?>;background-color: <?php echo ZCA_HEADER_TABS_BACKGROUND_COLOR; ?>;}
-#navCatTabs a:hover {color: <?php echo ZCA_HEADER_TABS_TEXT_COLOR_HOVER; ?>;background-color: <?php echo ZCA_HEADER_TABS_BACKGROUND_COLOR_HOVER; ?>;border: 2px solid <?php echo ZCA_HEADER_TABS_BORDER_COLOR_HOVER; ?>;}
+#navCatTabs a:hover {color: <?php echo ZCA_HEADER_TABS_TEXT_COLOR_HOVER; ?>;background-color: <?php echo ZCA_HEADER_TABS_BACKGROUND_COLOR_HOVER; ?>;}
 
 /* bof items for extra navCatTabs settings */
 

--- a/includes/templates/bootstrap/css/stylesheet_zca_colors.php
+++ b/includes/templates/bootstrap/css/stylesheet_zca_colors.php
@@ -11,6 +11,9 @@ a:hover {color: <?php echo ZCA_BUTTON_LINK_COLOR_HOVER; ?>;}
 .form-control::placeholder {color: <?php echo ZCA_BODY_PLACEHOLDER; ?>;}
 .required-info, .alert {color: <?php echo ZCA_BODY_PLACEHOLDER; ?>;}
 
+/* Nav Bar Active Links */
+.activeLink {color: <?php echo ZCA_ACTIVE_LINK_COLOR; ?> !important;background-color: <?php echo ZCA_ACTIVE_LINK_BACKGROUND_COLOR; ?> !important;border: 2px solid <?php echo ZCA_ACTIVE_LINK_BORDER_COLOR; ?> !important;}
+
 /* for button specific colors, examples are in stylesheet_css_buttons.css */
 /* buttons */
 .btn {color: <?php echo ZCA_BUTTON_TEXT_COLOR; ?>;background-color: <?php echo ZCA_BUTTON_COLOR; ?>;border-color: <?php echo ZCA_BUTTON_BORDER_COLOR; ?>;}
@@ -34,11 +37,19 @@ nav.navbar .navbar-toggler:hover {color: <?php echo ZCA_HEADER_NAVBAR_BUTTON_TEX
 /* header ezpage bar */
 #ezpagesBarHeader {background-color: <?php echo ZCA_HEADER_EZPAGE_BACKGROUND_COLOR; ?>;}
 #ezpagesBarHeader a.nav-link {color: <?php echo ZCA_HEADER_EZPAGE_LINK_COLOR; ?>;}
-#ezpagesBarHeader a.nav-link:hover {color: <?php echo ZCA_HEADER_EZPAGE_LINK_COLOR_HOVER; ?>;}
+#ezpagesBarHeader a.nav-link:hover {color: <?php echo ZCA_HEADER_EZPAGE_LINK_COLOR_HOVER; ?>;background-color: <?php echo ZCA_HEADER_EZPAGE_BACKGROUND_COLOR_HOVER; ?>;}
 
 /* header category tabs */
-#navCatTabs a {color: <?php echo ZCA_HEADER_TABS_TEXT_COLOR; ?>;background-color: <?php echo ZCA_HEADER_TABS_COLOR; ?>;}
-#navCatTabs a:hover {color: <?php echo ZCA_HEADER_TABS_TEXT_COLOR_HOVER; ?>;background-color: <?php echo ZCA_HEADER_TABS_COLOR_HOVER; ?>;}
+#navCatTabs a {color: <?php echo ZCA_HEADER_TABS_TEXT_COLOR; ?>;background-color: <?php echo ZCA_HEADER_TABS_BACKGROUND_COLOR; ?>;}
+#navCatTabs a:hover {color: <?php echo ZCA_HEADER_TABS_TEXT_COLOR_HOVER; ?>;background-color: <?php echo ZCA_HEADER_TABS_BACKGROUND_COLOR_HOVER; ?>;border: 2px solid <?php echo ZCA_HEADER_TABS_BORDER_COLOR_HOVER; ?>;}
+
+/* bof items for extra navCatTabs settings */
+
+/*  eof items for extra navCatTabs settings */
+
+/*  bof Extra Colors for Standard Checkout  */
+.bg-success {background-color: <?php echo ZCA_STD_CHECKOUT_PROGRESS_BAR_COLOR; ?> !important;}
+/*  eof Extra Colors for Standard Checkout  */
 
 /* breadcrumbs */
 #navBreadCrumb ol {background-color: <?php echo ZCA_BODY_BREADCRUMBS_BACKGROUND_COLOR; ?>;}
@@ -91,6 +102,7 @@ a.page-link:hover {color: <?php echo ZCA_BUTTON_PAGEINATION_TEXT_COLOR_HOVER; ?>
 
 /* product reviews */
 .productReviewCard:hover {background-color: <?php echo ZCA_CENTERBOX_CARD_BACKGROUND_COLOR_HOVER; ?>;}
+.rating {color: <?php echo ZCA_RATING_STAR_COLOR; ?>;background-color: <?php echo ZCA_RATING_STAR_BACKGROUND_COLOR; ?>;}
 
 /* product prices */
 .productBasePrice {color: <?php echo ZCA_BODY_PRODUCTS_BASE_COLOR; ?>;}
@@ -107,7 +119,7 @@ a.page-link:hover {color: <?php echo ZCA_BUTTON_PAGEINATION_TEXT_COLOR_HOVER; ?>
 //
 if (defined('ZCA_ADD_TO_CART_TEXT_COLOR')) {
 ?>
-#addToCart-card-header {color: <?php echo ZCA_ADD_TO_CART_TEXT_COLOR; ?>; background-color: <?php echo ZCA_ADD_TO_CART_BACKGROUND_COLOR; ?>;}
+#addToCart-card-header {color: <?php echo ZCA_ADD_TO_CART_TEXT_COLOR; ?> !important; background-color: <?php echo ZCA_ADD_TO_CART_BACKGROUND_COLOR; ?> !important;}
 #addToCart-card {border-color: <?php echo ZCA_ADD_TO_CART_BORDER_COLOR; ?>;}
 <?php
 }


### PR DESCRIPTION
Went from 80+ to 102 color-calls in the admin/includes/init_includes/init_bc_config.php to include both "seen" colors and those not "seen" (hovers, actives, etc.) by the accessibility checkers.

The includes/templates/bootstrap/css/stylesheet_zca_colors.php was rebuilt to reflect the colors in the init file.