### PR TITLE
#253: Color updates corrections

### DIFF
--- a/YOUR_ADMIN/includes/init_includes/init_bc_config.php
+++ b/YOUR_ADMIN/includes/init_includes/init_bc_config.php
@@ -7,7 +7,7 @@
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
  * @version $Id: init_bc_config.php
  *
- * BOOTSTRAP v3.5.2
+ * BOOTSTRAP v3.6.0
  */
 
 // -----
@@ -23,7 +23,7 @@ if (!isset($_SESSION['admin_id'])) {
 // is added, removed or updated.  Initially added for Bootstrap v3.5.2, note that
 // its setting might not be the same as the base template's version!
 //
-define('ZCA_BOOTSTRAP_COLORS_CURRENT_VERSION', '3.5.2');
+define('ZCA_BOOTSTRAP_COLORS_CURRENT_VERSION', '3.6.0-beta3');
 
 // -----
 // If this is an upgrade (or an initial install), load the installation/upgrade script to (at a minimum)

--- a/YOUR_ADMIN/includes/init_includes/init_bc_config_install_or_upgrade.php
+++ b/YOUR_ADMIN/includes/init_includes/init_bc_config_install_or_upgrade.php
@@ -138,7 +138,7 @@ $zca_bc_colors = [
         'configuration_title' => 'Alert Info Border Color',
         'configuration_value' => '#bee5eb',
         'sort_order' => 290,
-        'added' => '3.6.0,
+        'added' => '3.6.0',
     ],
     'ZCA_BODY_RATING_STAR_BACKGROUND_COLOR' => [
         'configuration_title' => '<b>Body Rating Stars</b> Background Color',

--- a/YOUR_ADMIN/includes/init_includes/init_bc_config_install_or_upgrade.php
+++ b/YOUR_ADMIN/includes/init_includes/init_bc_config_install_or_upgrade.php
@@ -271,7 +271,6 @@ $zca_bc_colors = [
         'configuration_value' => '#333333',
         'sort_order' => 2130,
         'added' => '3.6.0',
-        'set_default' => true,
     ],
     'ZCA_HEADER_NAVBAR_BUTTON_TEXT_COLOR' => [
         'configuration_title' => 'Header Nav Bar Button Text Color',
@@ -303,7 +302,7 @@ $zca_bc_colors = [
         'configuration_value' => '#919aa1',
         'sort_order' => 2200,
     ],
-    'ZCA_HEADER_TABS_BACKGROUND_COLOR' => [    
+    'ZCA_HEADER_TABS_BACKGROUND_COLOR' => [
         'configuration_title' => '<b>Header Category Tabs</b> Background Color',
         'configuration_value' => '#13607c',
         'sort_order' => 2500,

--- a/YOUR_ADMIN/includes/init_includes/init_bc_config_install_or_upgrade.php
+++ b/YOUR_ADMIN/includes/init_includes/init_bc_config_install_or_upgrade.php
@@ -167,12 +167,12 @@ $zca_bc_colors = [
         'configuration_value' => '#0056b3',
         'sort_order' => 1010,
     ],
-    'ZCA_BUTTON_BACKGROUND_COLOR' => [
+    'ZCA_BUTTON_COLOR' => [         //- Note, mis-named, should "really" be ZCA_BUTTON_BACKGROUND_COLOR; aliased on the storefront
         'configuration_title' => 'Button Background Color',
         'configuration_value' => '#13607c',
         'sort_order' => 1030,
     ],
-    'ZCA_BUTTON_BACKGROUND_COLOR_HOVER' => [
+    'ZCA_BUTTON_COLOR_HOVER' => [   //- Note, mis-named, should "really" be ZCA_BUTTON_BACKGROUND_COLOR_HOVER; aliased on the storefront
         'configuration_title' => 'Button Background Color on Hover',
         'configuration_value' => '#ffffff',
         'sort_order' => 1040,
@@ -282,12 +282,12 @@ $zca_bc_colors = [
         'configuration_value' => '#cccccc',
         'sort_order' => 2160,
     ],
-    'ZCA_HEADER_NAVBAR_BUTTON_BACKGROUND_COLOR' => [
+    'ZCA_HEADER_NAVBAR_BUTTON_COLOR' => [       //- Note, mis-named, should "really" be ZCA_HEADER_NAVBAR_BUTTON_BACKGROUND_COLOR; aliased on the storefront
         'configuration_title' => 'Header Nav Bar Button Background Color',
         'configuration_value' => '#343a40',
         'sort_order' => 2170,
     ],
-    'ZCA_HEADER_NAVBAR_BUTTON_BACKGROUND_COLOR_HOVER' => [
+    'ZCA_HEADER_NAVBAR_BUTTON_COLOR_HOVER' => [  //- Note, mis-named, should "really" be ZCA_HEADER_NAVBAR_BUTTON_BACKGROUND_COLOR_HOVER; aliased on the storefront
         'configuration_title' => 'Header Nav Bar Button Background Color on Hover',
         'configuration_value' => '#919aa1',
         'sort_order' => 2180,
@@ -302,12 +302,12 @@ $zca_bc_colors = [
         'configuration_value' => '#919aa1',
         'sort_order' => 2200,
     ],
-    'ZCA_HEADER_TABS_BACKGROUND_COLOR' => [
+    'ZCA_HEADER_TABS_COLOR' => [        //- Note, mis-named, should "really" be ZCA_HEADER_TABS_BACKGROUND_COLOR; aliased on the storefront
         'configuration_title' => '<b>Header Category Tabs</b> Background Color',
         'configuration_value' => '#13607c',
         'sort_order' => 2500,
     ],
-    'ZCA_HEADER_TABS_BACKGROUND_COLOR_HOVER' => [
+    'ZCA_HEADER_TABS_COLOR_HOVER' => [  //- Note, mis-named, should "really" be ZCA_HEADER_TABS_BACKGROUND_COLOR_HOVER; aliased on the storefront
         'configuration_title' => 'Header Category Tabs Background Color on Hover',
         'configuration_value' => '#ffffff',
         'sort_order' => 2510,
@@ -811,18 +811,26 @@ if (!defined('ZCA_BOOTSTRAP_COLORS_VERSION')) {
 //
 switch (true) {
     // -----
-    // v3.5.2: Major restructuring of the colors' titles and sort-orders.  The initialization section above has recorded
-    // all of the newly-added color settings.  Now, go back through each, updating each setting to use the now-current
-    // version of the colors' settings.
+    // If this was an *initial* installation, these updates have already been applied; nothing further to do.
     //
-    case !defined('ZCA_BOOTSTRAP_COLORS_VERSION'):                      //-Fall-through, essentially v3.5.2 upgrade
-    case version_compare(ZCA_BOOTSTRAP_COLORS_VERSION, '3.5.2', '<'):
+    case ($zca_bc_installed === true):
+        break;
+
+    // -----
+    // v3.5.2+: Major restructuring of the colors' titles and sort-orders.  The initialization section above has recorded
+    // all of the newly-added color settings for an initial installation.
+    //
+    // Go back through each, updating each setting to use the now-current version of the colors' settings.
+    //
+    // Note: Left as a 'case' statement just in case some future version needs to remove a setting.
+    //
+    case true:
         foreach ($zca_bc_colors as $key => $values) {
             $default_value = $values['configuration_value'];
             $added_version = (isset($values['added']) && $values['added'] >= '3.5.2') ? (' (Added in v'. $values['added'] . ')') : '';
             $default_color = ($zca_bc_installed === false && $added_version !== '' && empty($values['set_default'])) ? 'not-set' : $default_value;
             $description = "Default: $default_value.$added_version";
-            if (isset($values['added']) && $values['added'] === '3.5.2') {
+            if (isset($values['added'])) {
                 $db->Execute(
                     "INSERT IGNORE INTO " . TABLE_CONFIGURATION . "
                         (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added)
@@ -835,7 +843,8 @@ switch (true) {
                     SET configuration_title = '" . $values['configuration_title'] . "',
                         configuration_description = '$description',
                         sort_order = " . $values['sort_order'] . "
-                  WHERE configuration_key = '$key'"
+                  WHERE configuration_key = '$key'
+                  LIMIT 1"
             );
         }
     default:                                                            //-Fall-through from above.
@@ -860,13 +869,15 @@ if (!defined('ZCA_BOOTSTRAP_COLORS_VERSION')) {
          VALUES
             ('Bootstrap Colors Version', 'ZCA_BOOTSTRAP_COLORS_VERSION', '" . ZCA_BOOTSTRAP_COLORS_CURRENT_VERSION . "', 'Displays the current version of the <em>ZCA Bootstrap Colors</em> tool.', 6, now(), 0, 'zen_cfg_read_only(')"
     );
+} else {
+    $db->Execute(
+        "UPDATE " . TABLE_CONFIGURATION . "
+            SET configuration_value = '" . ZCA_BOOTSTRAP_COLORS_CURRENT_VERSION . "',
+                last_modified = now()
+          WHERE configuration_key = 'ZCA_BOOTSTRAP_COLORS_VERSION'
+          LIMIT 1"
+    );
 }
-$db->Execute(
-    "UPDATE " . TABLE_CONFIGURATION . "
-        SET configuration_value = '" . ZCA_BOOTSTRAP_COLORS_CURRENT_VERSION . "',
-            last_modified = now()
-      WHERE configuration_key = 'ZCA_BOOTSTRAP_COLORS_VERSION'"
-);
 
 // -----
 // If an initial installation wasn't also run, let the admin know that the upgrade was successfully completed.

--- a/docs/bootstrap/readme.html
+++ b/docs/bootstrap/readme.html
@@ -285,7 +285,7 @@ img {
     <h2>Version History</h2>
     <p>This section identifies the template's version history and changes, starting with its v2.0.0c release.  Prior version changes can be found in the root of the template's distribution zip-file (<code>CHANGELOG.txt</code>).</p>
     <ul>
-        <li>v3.6.0-beta2, 2023-07-01 (lat9, dbltoe, dennisns7d)<ul>
+        <li>v3.6.0-beta3, 2023-07-04 (lat9, dbltoe, dennisns7d)<ul>
             <li>BUGFIX: Simplify page-header processing for featured_products, products_all and products_new pages.</li>
             <li>BUGFIX: Don't provide changes for pricing-related notifications if they've already been handled.</li>
             <li>BUGFIX: &quot;Add Address&quot; button on <code>address_book</code> displays as &quot;Back&quot;.</li>
@@ -295,6 +295,7 @@ img {
             <li>BUGFIX: Add spacing for prices and min-max-unit elements for table-based product listings.</li>
             <li>BUGFIX: AJAX Search jQuery was using undefined constant; use Zen Cart default handling for timeouts.</li>
             <li>CHANGE: AJAX Search, enable observers to make modification(s) to query clauses; significant restructuring!</li>
+            <li>CHANGE: Colors added (and some defaults changed) for <em>Advanced Accessibility Standards</em>.</li>
             <li>The following files were changed or <span class="added">added</span>:<ol>
                 <li>/includes/classes/ajax/zcAjaxBootstrapSearch.php</li>
                 <li>/includes/classes/observers/ZcaBootstrapObserver.php</li>
@@ -308,10 +309,13 @@ img {
                 <li>/includes/modules/pages/products_new/header_php_products_new_zca_bootstrap.php</li>
                 <li>/includes/templates/bootstrap/template_info.php</li>
                 <li>/includes/templates/bootstrap/common/tpl_main_page.php</li>
+                <li>/includes/templates/bootstrap/css/stylesheet_zca_colors.php</li>
                 <li>/includes/templates/bootstrap/jscript/ajax_search.js</li>
                 <li>/includes/templates/bootstrap/jscript/ajax_search.min.js</li>
                 <li>/includes/templates/bootstrap/sideboxes/tpl_ajax_search_header.php</li>
                 <li>/includes/templates/bootstrap/templates/tpl_address_book_default.php</li>
+                <li>/YOUR_ADMIN/includes/init_includes/init_bc_config.php</li>
+                <li>/YOUR_ADMIN/includes/init_includes/init_bc_config_install_or_upgrade.php</li>
                 <li>/YOUR_ADMIN/includes/init_includes/init_zca_bootstrap_template_admin.php</li>
              </ol></li>
         </ul></li>

--- a/includes/templates/bootstrap/css/stylesheet_zca_colors.php
+++ b/includes/templates/bootstrap/css/stylesheet_zca_colors.php
@@ -2,7 +2,7 @@
 // -----
 // Part of the Bootstrap template, assigning colors based on those configured.
 //
-// BOOTSTRAP v3.5.2
+// BOOTSTRAP v3.6.0
 //
 // Starting with Bootstrap v3.5.2, any color-specifications defined in that and follow-on
 // versions start out, on an upgrade, with a value of 'not-set' to give the site a chance
@@ -45,6 +45,7 @@ $zca_bootstrap_colors_added = [
     'ZCA_PRIMARY_ADDRESS_CARD_HEADER_BACKGROUND_COLOR',
     'ZCA_PRIMARY_ADDRESS_CARD_HEADER_COLOR',
     'ZCA_PRIMARY_ADDRESS_CARD_BORDER_COLOR',
+
     // -----
     // Added in v3.6.0
     //
@@ -52,7 +53,32 @@ $zca_bootstrap_colors_added = [
     'ZCA_ALERT_INFO_BACKGROUND_COLOR',
     'ZCA_ALERT_INFO_BORDER_COLOR',
     'ZCA_HEADER_NAVBAR_LINK_BACKGROUND_COLOR_HOVER',
-    ];
+];
+
+// -----
+// There are a couple of "mis-named" color-configuration settings (these are 'legacy'
+// and won't be changed in the database).  For the purists amongst us, set definitions
+// that are used below (as of v3.6.0) that make more sense.
+//
+if (!defined('ZCA_BUTTON_BACKGROUND_COLOR')) {
+    define('ZCA_BUTTON_BACKGROUND_COLOR', ZCA_BUTTON_COLOR);
+}
+if (!defined('ZCA_BUTTON_BACKGROUND_COLOR_HOVER')) {
+    define('ZCA_BUTTON_BACKGROUND_COLOR_HOVER', ZCA_BUTTON_COLOR_HOVER);
+}
+if (!defined('ZCA_HEADER_NAVBAR_BUTTON_BACKGROUND_COLOR')) {
+    define('ZCA_HEADER_NAVBAR_BUTTON_BACKGROUND_COLOR', ZCA_HEADER_NAVBAR_BUTTON_COLOR);
+}
+if (!defined('ZCA_HEADER_NAVBAR_BUTTON_BACKGROUND_COLOR_HOVER')) {
+    define('ZCA_HEADER_NAVBAR_BUTTON_BACKGROUND_COLOR_HOVER', ZCA_HEADER_NAVBAR_BUTTON_COLOR_HOVER);
+}
+if (!defined('ZCA_HEADER_TABS_BACKGROUND_COLOR')) {
+    define('ZCA_HEADER_TABS_BACKGROUND_COLOR', ZCA_HEADER_TABS_COLOR);
+}
+if (!defined('ZCA_HEADER_TABS_BACKGROUND_COLOR_HOVER')) {
+    define('ZCA_HEADER_TABS_BACKGROUND_COLOR_HOVER', ZCA_HEADER_TABS_COLOR_HOVER);
+}
+
 // -----
 // Each of the newly-added color values is saved as a lower-case variable
 // of the same name, e.g. ZCA_BODY_RATING_STAR_COLOR becomes $zca_body_rating_star_color)
@@ -69,18 +95,25 @@ foreach ($zca_bootstrap_colors_added as $next_color) {
 <?php
 //- Body
 ?>
-body {color: <?php echo ZCA_BODY_TEXT_COLOR; ?>;background-color: <?php echo ZCA_BODY_BACKGROUND_COLOR; ?>;}
-a {color: <?php echo ZCA_BUTTON_LINK_COLOR; ?>;}
-a:hover {color: <?php echo ZCA_BUTTON_LINK_COLOR_HOVER; ?>;}
+body {
+    color: <?php echo ZCA_BODY_TEXT_COLOR; ?>;
+    background-color: <?php echo ZCA_BODY_BACKGROUND_COLOR; ?>;
+}
+a {
+    color: <?php echo ZCA_BUTTON_LINK_COLOR; ?>;
+}
+a:hover {
+    color: <?php echo ZCA_BUTTON_LINK_COLOR_HOVER; ?>;
+}
 .form-control::placeholder,
 .required-info,
 span.alert {
     color: <?php echo ZCA_BODY_PLACEHOLDER; ?>;
 }
 .alert-info {
-    color: <?php echo ZCA_ALERT_INFO_COLOR; ?>;
-    background-color: <?php echo ZCA_ALERT_INFO_BACKGROUND_COLOR; ?>;
-    border-color: <?php echo ZCA_ALERT_INFO_BORDER_COLOR; ?>;
+    <?php echo ($zca_alert_info_color !== '') ? "color: $zca_alert_info_color;" : ''; ?>
+    <?php echo ($zca_alert_info_background_color !== '') ? "background-color: $zca_alert_info_background_color;" : ''; ?>
+    <?php echo ($zca_alert_info_border_color !== '') ? "border-color: $zca_alert_info_border_color;" : ''; ?>
 }
 .rating {
     <?php echo ($zca_body_rating_star_background_color !== '') ? "background-color: $zca_body_rating_star_background_color;" : ''; ?>
@@ -119,7 +152,7 @@ nav.navbar a.nav-link {
 }
 nav.navbar a.nav-link:hover {
     color: <?php echo ZCA_HEADER_NAVBAR_LINK_COLOR_HOVER; ?>;
-    background-color: <?php echo ZCA_HEADER_NAVBAR_LINK_BACKGROUND_COLOR_HOVER; ?>;
+    <?php echo ($zca_header_navbar_link_background_color_hover !== '') ? "background-color: $zca_header_navbar_link_background_color_hover;" : ''; ?>
 }
 nav.navbar .navbar-toggler {
     color: <?php echo ZCA_HEADER_NAVBAR_BUTTON_TEXT_COLOR; ?>;


### PR DESCRIPTION
Correcting
- Storefront CSS handling for newly-added color values
- Reverting color-name changes in admin configuration and streamlining the install/upgrade processing
- Identifying v3.6.0 as the now-current version for the configuration settings so that the upgrade processing will run.