### PR TITLE
#261: Sold Out coloring and cursor

### DIFF
--- a/YOUR_ADMIN/includes/init_includes/init_bc_config.php
+++ b/YOUR_ADMIN/includes/init_includes/init_bc_config.php
@@ -23,7 +23,7 @@ if (!isset($_SESSION['admin_id'])) {
 // is added, removed or updated.  Initially added for Bootstrap v3.5.2, note that
 // its setting might not be the same as the base template's version!
 //
-define('ZCA_BOOTSTRAP_COLORS_CURRENT_VERSION', '3.6.0-beta5');
+define('ZCA_BOOTSTRAP_COLORS_CURRENT_VERSION', '3.6.0-beta6');
 
 // -----
 // If this is an upgrade (or an initial install), load the installation/upgrade script to (at a minimum)

--- a/YOUR_ADMIN/includes/init_includes/init_bc_config_install_or_upgrade.php
+++ b/YOUR_ADMIN/includes/init_includes/init_bc_config_install_or_upgrade.php
@@ -642,7 +642,7 @@ $zca_bc_colors = [
     ],
 
     // -----
-    // Checkout-related colors sort-orders range from 7000-7999
+    // Checkout-related colors sort-orders range from 7000-7499
     //
     'ZCA_CHECKOUT_PROGRESS_BAR_BACKGROUND_COLOR' => [
         'configuration_title' => '<b>Checkout 3-Page</b> Progress Bar Background Color',
@@ -722,6 +722,28 @@ $zca_bc_colors = [
         'configuration_value' => '#f2c200',
         'sort_order' => 7400,
         'added' => '3.5.2',
+    ],
+
+    // -----
+    // "Sold Out" button coloring sort-orders range from 7500-7519
+    //
+    'ZCA_SOLD_OUT_BACKGROUND_COLOR' => [
+        'configuration_title' => '<b>Sold Out Button</b> Background Color',
+        'configuration_value' => '#a80000',
+        'sort_order' => 7500,
+        'added' => '3.6.0',
+    ],
+    'ZCA_SOLD_OUT_COLOR' => [
+        'configuration_title' => 'Sold Out Button Color',
+        'configuration_value' => '#ffffff',
+        'sort_order' => 7505,
+        'added' => '3.6.0',
+    ],
+    'ZCA_SOLD_OUT_BORDER_COLOR' => [
+        'configuration_title' => 'Sold Out Button Border Color',
+        'configuration_value' => '#a80000',
+        'sort_order' => 7510,
+        'added' => '3.6.0',
     ],
 
     // -----
@@ -837,7 +859,6 @@ if (!defined('ZCA_BOOTSTRAP_COLORS_VERSION')) {
     // defined.
     //
     if ($zca_bc_installed === true) {
-        $messageStack->add(sprintf(SUCCESS_ZCA_BOOTSTRAP_COLORS_INSTALLED, ZCA_BOOTSTRAP_COLORS_CURRENT_VERSION), 'success');
         $messageStack->add_session(sprintf(SUCCESS_ZCA_BOOTSTRAP_COLORS_INSTALLED, ZCA_BOOTSTRAP_COLORS_CURRENT_VERSION), 'success');
     }
 }
@@ -919,6 +940,5 @@ if (!defined('ZCA_BOOTSTRAP_COLORS_VERSION')) {
 // If an initial installation wasn't also run, let the admin know that the upgrade was successfully completed.
 //
 if ($zca_bc_installed === false) {
-    $messageStack->add(sprintf(SUCCESS_ZCA_BOOTSTRAP_COLORS_UPDATED, ZCA_BOOTSTRAP_COLORS_CURRENT_VERSION), 'success');
     $messageStack->add_session(sprintf(SUCCESS_ZCA_BOOTSTRAP_COLORS_UPDATED, ZCA_BOOTSTRAP_COLORS_CURRENT_VERSION), 'success');
 }

--- a/includes/classes/observers/ZcaBootstrapObserver.php
+++ b/includes/classes/observers/ZcaBootstrapObserver.php
@@ -2,7 +2,7 @@
 // -----
 // Part of the ZCA Bootstrap template, @zcadditions, @lat9, @marco-pm
 //
-// BOOTSTRAP 3.5.2
+// BOOTSTRAP 3.6.0
 //
 class ZcaBootstrapObserver extends base
 {
@@ -31,7 +31,7 @@ class ZcaBootstrapObserver extends base
 
         if (zca_bootstrap_active()) {
             $this->attach(
-                $this, 
+                $this,
                 [
                     //- From /includes/functions/functions_prices.php (zen_get_products_display)
                     'NOTIFY_ZEN_GET_PRODUCTS_DISPLAY_PRICE_SALE',
@@ -303,7 +303,7 @@ class ZcaBootstrapObserver extends base
                     $sold_out_button_class = 'button_sold_out_sm';
                     $sold_out_button_name = BUTTON_SOLD_OUT_SMALL_ALT;
                 }
-                $p2 = '<button class="btn ' . $sold_out_button_class . '" type="button">' . $sold_out_button_name . '</button>';
+                $p2 = '<button class="btn ' . $sold_out_button_class . '" type="button" disabled>' . $sold_out_button_name . '</button>';
                 break;
 
             case 'NOTIFY_ORDER_COUPON_LINK':

--- a/includes/templates/bootstrap/css/stylesheet_zca_colors.php
+++ b/includes/templates/bootstrap/css/stylesheet_zca_colors.php
@@ -59,6 +59,9 @@ $zca_bootstrap_colors_added = [
     'ZCA_HEADER_NAVBAR_EXTRA_BUTTON_BACKGROUND_COLOR_HOVER',
     'ZCA_HEADER_NAVBAR_EXTRA_BUTTON_BORDER_COLOR',
     'ZCA_HEADER_NAVBAR_EXTRA_BUTTON_BORDER_COLOR_HOVER',
+    'ZCA_SOLD_OUT_BACKGROUND_COLOR',
+    'ZCA_SOLD_OUT_COLOR',
+    'ZCA_SOLD_OUT_BORDER_COLOR',
 ];
 
 // -----
@@ -466,6 +469,14 @@ button.button_confirm_order:hover {
 #checkoutConfirmationDefault .progress-bar,
 #checkoutSuccessDefault .progress-bar {
     <?php echo ($zca_checkout_progress_bar_background_color !== '') ? "background-color: $zca_checkout_progress_bar_background_color!important;" : ''; ?>
+}
+<?php
+//- "Sold Out" button colors (it's not a hoverable/clickable button).
+?>
+button.button_sold_out_sm, button.button_sold_out_sm:hover, button.button_sold_out, button.button_sold_out:hover {
+    <?php echo ($zca_sold_out_background_color !== '') ? "background-color: $zca_sold_out_background_color;" : ''; ?>
+    <?php echo ($zca_sold_out_color !== '') ? "color: $zca_sold_out_color;" : ''; ?>
+    <?php echo ($zca_sold_out_border_color !== '') ? "border-color: $zca_sold_out_border_color;" : ''; ?>
 }
 <?php
 //- Carousel prev/next and indicators


### PR DESCRIPTION
Adding coloring for the Sold Out buttons, which need to be `disabled` so that the cursor will not show as a pointer.

Unfortunately, the notification exists only in the zc158 series; see comments on the subject issue for more details.