### PR TITLE
#266: Floating "Add Selected to Cart"

### DIFF
--- a/docs/bootstrap/readme.html
+++ b/docs/bootstrap/readme.html
@@ -69,7 +69,7 @@ img {
 
 <body>
     <h1>Bootstrap-4 Template for Zen Cart v1.5.7 and v1.5.8</h1>
-    <p>Version 3.6.0, by lat9, drbyte, scottcwilson, marco-pm, dbltoe, dennisns7d, brittainmark and torvista</p>
+    <p>Version 3.6.0, by lat9, drbyte, scottcwilson, marco-pm, dbltoe, dennisns7d, brittainmark, torvista and proseLA</p>
     <p>Current Support Thread at Zen Cart Forums: <a href="https://www.zen-cart.com/showthread.php?223910-ZCA-Bootstrap-4-Template-Support-Thread" target="_blank">https://www.zen-cart.com/showthread.php?223910-ZCA-Bootstrap-4-Template-Support-Thread</a></p>
     <p>Zen Cart Download Link: <a href="https://www.zen-cart.com/downloads.php?do=file&id=2191" target="_blank">https://www.zen-cart.com/downloads.php?do=file&id=2191</a></p>
     <p>GitHub repository: <a href="https://github.com/lat9/ZCA-Bootstrap-Template" target="_blank">https://github.com/lat9/ZCA-Bootstrap-Template</a></p>
@@ -287,7 +287,7 @@ img {
     <h2>Version History</h2>
     <p>This section identifies the template's version history and changes, starting with its v2.0.0c release.  Prior version changes can be found in the root of the template's distribution zip-file (<code>CHANGELOG.txt</code>).</p>
     <ul>
-        <li>v3.6.0-beta5, 2023-07-13 (lat9, dbltoe, dennisns7d, brittainmark)<ul>
+        <li>v3.6.0-beta5, 2023-07-19 (lat9, dbltoe, dennisns7d, brittainmark, proseLA)<ul>
             <li>BUGFIX: Simplify page-header processing for featured_products, products_all and products_new pages.</li>
             <li>BUGFIX: Don't provide changes for pricing-related notifications if they've already been handled.</li>
             <li>BUGFIX: &quot;Add Address&quot; button on <code>address_book</code> displays as &quot;Back&quot;.</li>
@@ -303,7 +303,8 @@ img {
             <li>BUGFIX: Adding text/background/border color-constants for the <var>Sold Out</var> button and disable that button so it doesn't appear clickable (which it isn't).</li>
             <li>BUGFIX: Correcting HTML validation error on additional images' modal pop-up.</li>
             <li>CHANGE: Supporting zc158+ call-for-price product's interaction with ask-a-question.</li>
-            <li>CHANGE: Supporting zc158a+ newly defined constant for the <var>account_history_info</var> page.
+            <li>CHANGE: Supporting zc158a+ newly defined constant for the <var>account_history_info</var> page.</li>
+            <li>CHANGE: 'Float' the <em>Add Selected to Cart</em> button as it tends to get &quot;lost&quot;.</li>
             <li>The following files were changed or <span class="added">added</span>:<ol>
                 <li>/includes/classes/ajax/zcAjaxBootstrapSearch.php</li>
                 <li>/includes/classes/observers/ZcaBootstrapObserver.php</li>
@@ -319,6 +320,7 @@ img {
                 <li>/includes/modules/pages/products_new/header_php_products_new_zca_bootstrap.php</li>
                 <li>/includes/templates/bootstrap/template_info.php</li>
                 <li>/includes/templates/bootstrap/common/tpl_main_page.php</li>
+                <li><span class="added">/includes/templates/bootstrap/css/stylesheet_360.css</span></li>
                 <li>/includes/templates/bootstrap/css/stylesheet_zca_colors.php</li>
                 <li>/includes/templates/bootstrap/jscript/ajax_search.js</li>
                 <li>/includes/templates/bootstrap/jscript/ajax_search.min.js</li>

--- a/includes/templates/bootstrap/css/stylesheet_360.css
+++ b/includes/templates/bootstrap/css/stylesheet_360.css
@@ -1,0 +1,5 @@
+.btn.button_add_selected {
+    position: fixed;
+    bottom: 7.5rem;
+    z-index: 100;
+}

--- a/includes/templates/bootstrap/templates/tpl_modules_product_listing.php
+++ b/includes/templates/bootstrap/templates/tpl_modules_product_listing.php
@@ -2,7 +2,7 @@
 /**
  * Module Template
  * 
- * BOOTSTRAP v3.1.6
+ * BOOTSTRAP v3.6.0
  *
  * @copyright Copyright 2003-2020 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
@@ -13,8 +13,11 @@ require DIR_WS_MODULES . zen_get_module_directory(FILENAME_PRODUCT_LISTING);
 ?>
 <div id="productsListing" class="listingCenterColumn">
 <?php
-// only show when there is something to submit and enabled
-if ($show_top_submit_button == true) {
+// -----
+// v3.6.0: Adding float-button class so it's always visible whether top or bottom
+// location is specified via configuration.
+//
+if ($show_top_submit_button === true || $show_bottom_submit_button === true) {
 ?>
     <div id="productsListing-btn-toolbarTop" class="btn-toolbar justify-content-end my-3" role="toolbar">
         <?php echo zen_image_submit(BUTTON_IMAGE_ADD_PRODUCTS_TO_CART, BUTTON_ADD_PRODUCTS_TO_CART_ALT, 'id="submit1" name="submit1"'); ?>
@@ -57,8 +60,10 @@ if ($listing_split->number_of_rows && (PREV_NEXT_BAR_LOCATION == '2' || PREV_NEX
 }
 ?>
 <?php
-// only show when there is something to submit and enabled
-if ($show_bottom_submit_button == true) {
+// -----
+// v3.6.0; "Add Selected to Cart" button now floats, this'll be removed in the next release.
+//
+if (false && $show_bottom_submit_button == true) {
 ?>
     <div id="productsListing-btn-toolbarBottom" class="btn-toolbar justify-content-end my-3" role="toolbar">
         <?php echo zen_image_submit(BUTTON_IMAGE_ADD_PRODUCTS_TO_CART, BUTTON_ADD_PRODUCTS_TO_CART_ALT, 'id="submit2" name="submit1"'); ?>


### PR DESCRIPTION
Note that there's an additional `.css` file (stylesheet_360.css).  Without that, a site's browser-cached version of the base stylesheet.css would require customers to "Force Reload" to bring the styling in.