### PR TITLE
Prevent empty h1 tag

### DIFF
--- a/includes/templates/bootstrap/templates/tpl_index_categories.php
+++ b/includes/templates/bootstrap/templates/tpl_index_categories.php
@@ -23,7 +23,9 @@ if ($show_welcome === true) {
     //
     $heading_title = (defined('HEADING_TITLE_NESTED')) ? HEADING_TITLE_NESTED : HEADING_TITLE;
 ?>
+<?php if (!empty($heading_title)) { ?>
     <h1 id="indexCategories-pageHeading" class="pageHeading"><?php echo $heading_title; ?></h1>
+<?php } ?>
 <?php
     if (SHOW_CUSTOMER_GREETING === '1') {
 ?>

--- a/includes/templates/bootstrap/templates/tpl_index_default.php
+++ b/includes/templates/bootstrap/templates/tpl_index_default.php
@@ -16,7 +16,9 @@
 ?>
 <div id="indexDefault" class="centerColumn">
 
+<?php if (!empty(HEADING_TITLE)) { ?>
 <h1 id="indexDefault-pageHeading" class="pageHeading"><?php echo HEADING_TITLE; ?></h1>
+<?php } ?>
 
 <?php if (SHOW_CUSTOMER_GREETING == 1) { ?>
 <h2 id="indexDefault-greeting" class="greeting"><?php echo zen_customer_greeting(); ?></h2>

--- a/includes/templates/bootstrap/templates/tpl_index_product_list.php
+++ b/includes/templates/bootstrap/templates/tpl_index_product_list.php
@@ -15,7 +15,10 @@
  */
 ?>
 <div id="indexProductList" class="centerColumn">
+
+<?php if (!empty($current_categories_name)) { ?>
     <h1 id="indexProductList-pageHeading" class="pageHeading"><?php echo $current_categories_name; ?></h1>
+<?php } ?>
 
     <div id="indexProductList-cat-wrap">
 <?php


### PR DESCRIPTION
An empty h1 tag is an accessibility violation, which is reported as an error by WAVE. 