### PR TITLE
#271: Correct accessibility issue on index pages (empty <h1>)

### DIFF
--- a/YOUR_ADMIN/includes/init_includes/init_zca_bootstrap_template_admin.php
+++ b/YOUR_ADMIN/includes/init_includes/init_zca_bootstrap_template_admin.php
@@ -9,7 +9,7 @@ if (!defined('IS_ADMIN_FLAG')) {
     die('Illegal Access');
 }
 
-define('ZCA_BOOTSTRAP_CURRENT_VERSION', '3.6.0');
+define('ZCA_BOOTSTRAP_CURRENT_VERSION', '3.6.1-beta1');
 
 // -----
 // If a SuperUser admin is logged in, check to see that all of the new configuration settings required

--- a/docs/bootstrap/readme.html
+++ b/docs/bootstrap/readme.html
@@ -69,7 +69,7 @@ img {
 
 <body>
     <h1>Bootstrap-4 Template for Zen Cart v1.5.7 and v1.5.8</h1>
-    <p>Version 3.6.0, by lat9, drbyte, scottcwilson, marco-pm, dbltoe, dennisns7d, brittainmark, torvista and proseLA</p>
+    <p>Version 3.6.1, by lat9, drbyte, scottcwilson, marco-pm, dbltoe, dennisns7d, brittainmark, torvista and proseLA</p>
     <p>Current Support Thread at Zen Cart Forums: <a href="https://www.zen-cart.com/showthread.php?223910-ZCA-Bootstrap-4-Template-Support-Thread" target="_blank">https://www.zen-cart.com/showthread.php?223910-ZCA-Bootstrap-4-Template-Support-Thread</a></p>
     <p>Zen Cart Download Link: <a href="https://www.zen-cart.com/downloads.php?do=file&id=2191" target="_blank">https://www.zen-cart.com/downloads.php?do=file&id=2191</a></p>
     <p>GitHub repository: <a href="https://github.com/lat9/ZCA-Bootstrap-Template" target="_blank">https://github.com/lat9/ZCA-Bootstrap-Template</a></p>
@@ -287,6 +287,16 @@ img {
     <h2>Version History</h2>
     <p>This section identifies the template's version history and changes, starting with its v2.0.0c release.  Prior version changes can be found in the root of the template's distribution zip-file (<code>CHANGELOG.txt</code>).</p>
     <ul>
+        <li>v3.6.1-beta1, 2023-08-03 (lat9, scottcwilson)<ul>
+            <li>BUGFIX: Correct empty level-1 headings (accessibility issue) on index pages.</li>
+             <li>The following files were changed:<ol>
+                <li>/includes/languages/english/extra_definitions/bootstrap/lang.zca_bootstrap_common.php</li>
+                <li>/includes/languages/english/extra_definitions/bootstrap/zca_bootstrap_common.php</li>
+                <li>/includes/templates/bootstrap/templates/tpl_index_default.php</li>
+                <li>/includes/templates/bootstrap/templates/tpl_index_categories.php</li>
+                <li>/YOUR_ADMIN/includes/init_includes/init_zca_bootstrap_template_admin.php</li>
+            </ol></li>
+        </ul></li>
         <li>v3.6.0, 2023-07-20 (lat9, dbltoe, dennisns7d, brittainmark, proseLA)<ul>
             <li>BUGFIX: Simplify page-header processing for featured_products, products_all and products_new pages.</li>
             <li>BUGFIX: Don't provide changes for pricing-related notifications if they've already been handled.</li>

--- a/includes/languages/english/extra_definitions/bootstrap/lang.zca_bootstrap_common.php
+++ b/includes/languages/english/extra_definitions/bootstrap/lang.zca_bootstrap_common.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * BOOTSTRAP v3.6.0
+ * BOOTSTRAP v3.6.1
  */
 // -----
 // Part of the Bootstrap template, defining commonly-used phrases and phrases unique to the bootstrap template.
@@ -99,5 +99,13 @@ $define = [
 //
     'TEXT_HEADER_ARIA_LABEL_NAVBAR' =>'Navigation Bar',
     'TEXT_HEADER_ARIA_LABEL_LOGO' => 'Site Logo',
+
+// -----
+// <h1> text for index pages where the 'normal' heading-text isn't used by a
+// store ... for accessibility.
+//
+// Note: For zc200, this constant will be in /includes/languages/english/lang.index.php.
+//
+    'HEADING_TITLE_SCREENREADER' => 'See Additional Content Below',
 ];
 return $define;

--- a/includes/languages/english/extra_definitions/bootstrap/zca_bootstrap_common.php
+++ b/includes/languages/english/extra_definitions/bootstrap/zca_bootstrap_common.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * BOOTSTRAP v3.6.0
+ * BOOTSTRAP v3.6.1
  */
 // -----
 // Part of the Bootstrap template, defining commonly-used phrases and phrases unique to the bootstrap template.
@@ -106,3 +106,11 @@ define('TEXT_HEADER_ARIA_LABEL_LOGO', 'Site Logo');
 // defined in lang.english.php for zc158 and later.
 //
 define('PAGE_ACCOUNT_HISTORY', 'Order History');
+
+// -----
+// <h1> text for index pages where the 'normal' heading-text isn't provided by a
+// store ... for accessibility.
+//
+// Note: For zc200, this constant will be in /includes/languages/english/lang.index.php.
+//
+define('HEADING_TITLE_SCREENREADER', 'See Additional Content Below');

--- a/includes/templates/bootstrap/templates/tpl_index_categories.php
+++ b/includes/templates/bootstrap/templates/tpl_index_categories.php
@@ -2,10 +2,10 @@
 /**
  * Page Template
  * 
- * BOOTSTRAP v3.5.2
+ * BOOTSTRAP v3.6.1
  *
- * Loaded by main_page=index<br />
- * Displays category/sub-category listing<br />
+ * Loaded by main_page=index
+ * Displays category/sub-category listing
  * Uses tpl_index_category_row.php to render individual items
  *
  * @copyright Copyright 2003-2020 Zen Cart Development Team
@@ -22,8 +22,18 @@ if ($show_welcome === true) {
     // otherwise fall-back to the legacy title.
     //
     $heading_title = (defined('HEADING_TITLE_NESTED')) ? HEADING_TITLE_NESTED : HEADING_TITLE;
+
+    // -----
+    // For accessibility, an <h1> tag can't contain an empty string.  If that's the case, use
+    // generic wording for the title and render the <h1> tag for screen-readers only.
+    //
+    $screen_reader_only = '';
+    if ($heading_title === '') {
+        $heading_title = HEADING_TITLE_SCREENREADER;
+        $screen_reader_only = ' sr-only';
+    }
 ?>
-    <h1 id="indexCategories-pageHeading" class="pageHeading"><?php echo $heading_title; ?></h1>
+    <h1 id="indexCategories-pageHeading" class="pageHeading<?php echo $screen_reader_only; ?>"><?php echo $heading_title; ?></h1>
 <?php
     if (SHOW_CUSTOMER_GREETING === '1') {
 ?>

--- a/includes/templates/bootstrap/templates/tpl_index_default.php
+++ b/includes/templates/bootstrap/templates/tpl_index_default.php
@@ -2,7 +2,7 @@
 /**
  * Page Template
  * 
- * BOOTSTRAP v3.5.2
+ * BOOTSTRAP v3.6.1
  *
  * Main index page<br />
  * Displays greetings, welcome text (define-page content), and various centerboxes depending on switch settings in Admin<br />
@@ -15,8 +15,19 @@
  */
 ?>
 <div id="indexDefault" class="centerColumn">
-
-<h1 id="indexDefault-pageHeading" class="pageHeading"><?php echo HEADING_TITLE; ?></h1>
+<?php
+// -----
+// For accessibility, an <h1> tag can't contain an empty string.  If that's the case, use
+// generic wording for the title and render the <h1> tag for screen-readers only.
+//
+$screen_reader_only = '';
+$heading_title = HEADING_TITLE;
+if ($heading_title === '') {
+    $heading_title = HEADING_TITLE_SCREENREADER;
+    $screen_reader_only = ' sr-only';
+}
+?>
+<h1 id="indexDefault-pageHeading" class="pageHeading<?php echo $screen_reader_only; ?>"><?php echo $heading_title; ?></h1>
 
 <?php if (SHOW_CUSTOMER_GREETING == 1) { ?>
 <h2 id="indexDefault-greeting" class="greeting"><?php echo zen_customer_greeting(); ?></h2>


### PR DESCRIPTION
Note that for zc200 the newly-added constant is anticipated to be in /includes/languages/english/lang.index.php.

Replaces PR #270.