### PR TITLE
Changes required for accessibility page

### DIFF
--- a/includes/modules/sideboxes/bootstrap/information.php
+++ b/includes/modules/sideboxes/bootstrap/information.php
@@ -60,6 +60,9 @@ if (DEFINE_PRIVACY_STATUS <= 1) {
 if (DEFINE_CONDITIONS_STATUS <= 1) {
     $information[] = '<a class="' . $information_classes . '" href="' . zen_href_link(FILENAME_CONDITIONS) . '">' . BOX_INFORMATION_CONDITIONS . '</a>';
 }
+if (defined('FILENAME_ACCESSIBILITY') && (!empty($flag_show_accessibility_sidebox_link))) {
+    $information[] = '<a class="' . $information_classes . '" href="' . zen_href_link(FILENAME_ACCESSIBILITY) . '">' . BOX_INFORMATION_ACCESSIBILITY . '</a>';
+}
 if (DEFINE_CONTACT_US_STATUS <= 1) {
     $information[] = '<a class="' . $information_classes . '" href="' . zen_href_link(FILENAME_CONTACT_US, '', 'SSL') . '">' . BOX_INFORMATION_CONTACT . '</a>';
 }

--- a/includes/templates/bootstrap/templates/tpl_site_map_default.php
+++ b/includes/templates/bootstrap/templates/tpl_site_map_default.php
@@ -77,6 +77,11 @@ if (DEFINE_CONDITIONS_STATUS <= '1') {
                 <li class="list-group-item"><?php echo '<a href="' . zen_href_link(FILENAME_CONDITIONS) . '">' . BOX_INFORMATION_CONDITIONS . '</a>'; ?></li>
 <?php
 }
+if (defined('FILENAME_ACCESSIBILITY') && (!empty($flag_show_accessibility_sidebox_link))) {
+?>
+                <li class="list-group-item"><?php echo '<a href="' . zen_href_link(FILENAME_ACCESSIBILITY) . '">' . BOX_INFORMATION_ACCESSIBILITY . '</a>'; ?></li>
+<?php
+}
 if (DEFINE_CONTACT_US_STATUS <= '1') {
 ?>
                 <li class="list-group-item"><?php echo '<a href="' . zen_href_link(FILENAME_CONTACT_US, '', 'SSL') . '">' . BOX_INFORMATION_CONTACT . '</a>'; ?></li>


### PR DESCRIPTION
Checks if FILENAME_ACCESSIBILITY is defined for backwards compatibility and compatibility with older Zen Cart versions that have used the accessibility page plugin.  Tested on 2.0.0-b1 with plugin installed (the build was done before Zen Cart PR https://github.com/zencart/zencart/pull/6269 was merged.)