### PR TITLE
Colors configuration_group should not be `visible`

### DIFF
--- a/YOUR_ADMIN/includes/init_includes/init_bc_config_install_or_upgrade.php
+++ b/YOUR_ADMIN/includes/init_includes/init_bc_config_install_or_upgrade.php
@@ -29,7 +29,7 @@ if (!$configuration->EOF) {
         "INSERT INTO " . TABLE_CONFIGURATION_GROUP . "
             (configuration_group_title, configuration_group_description, sort_order, visible)
          VALUES
-            ('$bc_menu_title', '$bc_menu_title', 1, 1)"
+            ('$bc_menu_title', '$bc_menu_title', 1, 0)"
     );
     $bccid = $db->Insert_ID();
     $db->Execute(


### PR DESCRIPTION
Since there's an Admin `Tools` menu entry for editing colors, which is more user-friendly than the default `configuration` version of the page, that Group should be set as `not visible`.

It's already not showing up in the list by virtue of the side-effect of not registering the Group as an authorized Admin page. But for thoroughness it should be set to `0`

Undecided whether it's important to address on an upgrade, so didn't PR that.