### PR TITLE
Adding check for "Show Greeting" setting

### DIFF
--- a/includes/templates/bootstrap/templates/tpl_index_default.php
+++ b/includes/templates/bootstrap/templates/tpl_index_default.php
@@ -20,14 +20,13 @@
 // For accessibility, an <h1> tag can't contain an empty string.  If that's the case, use
 // generic wording for the title and render the <h1> tag for screen-readers only.
 //
-$screen_reader_only = '';
-$heading_title = HEADING_TITLE;
-if ($heading_title === '') {
-    $heading_title = HEADING_TITLE_SCREENREADER;
-    $screen_reader_only = ' sr-only';
-}
 ?>
+
+<?php if ($show_welcome == true && zen_not_null(HEADING_TITLE)) { ?>
 <h1 id="indexDefault-pageHeading" class="pageHeading<?php echo $screen_reader_only; ?>"><?php echo $heading_title; ?></h1>
+<?php } else { ?>
+<h1 id="indexDefault-pageHeading" class="pageHeading sr-only"><?php echo HEADING_TITLE_SCREENREADER; ?></h1>
+<?php } ?>
 
 <?php if (SHOW_CUSTOMER_GREETING == 1) { ?>
 <h2 id="indexDefault-greeting" class="greeting"><?php echo zen_customer_greeting(); ?></h2>


### PR DESCRIPTION
This setting can be configured in the ZC Admin Backend under "Configuration > Layout Settings > Switch Customer Greeting > Show on Index" and Set to 0.

The value is set in `/includes/init_includes/init_category_path.php` of ZC's base code.